### PR TITLE
refactor: #26 매칭완료 시 ES에서 데이터 삭제 로직 제거

### DIFF
--- a/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingProcessor.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingProcessor.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 
 import com.matching.ezgg.matching.dto.MatchingFilterParsingDto;
 import com.matching.ezgg.matching.infra.es.service.EsMatchingFilter;
-import com.matching.ezgg.matching.infra.es.service.EsService;
 import com.matching.ezgg.matching.infra.redis.RedisStreamProducer;
 
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,6 @@ public class MatchingProcessor {
 
 	private final EsMatchingFilter esMatchingFilter;
 	private final RedisStreamProducer redisStreamProducer;
-	private final EsService esService;
 
 	public void tryMatch(MatchingFilterParsingDto matchingFilterParsingDto) {
 		try {
@@ -44,11 +42,6 @@ public class MatchingProcessor {
 			log.info("매칭 성공! >>>>> {} : {}", matchingFilterParsingDto.getMemberId(), bestMatchingUser.getMemberId());
 
 			redisStreamProducer.acknowledgeBothUser(matchingFilterParsingDto, bestMatchingUser);
-
-			// ES에서 매칭된 유저들의 데이터 삭제
-			esService.deleteDocByMemberId(matchingFilterParsingDto.getMemberId());
-			esService.deleteDocByMemberId(bestMatchingUser.getMemberId());
-
 			redisStreamProducer.removeRetryCandidate(matchingFilterParsingDto);
 			redisStreamProducer.removeRetryCandidate(bestMatchingUser);
 		} catch (Exception e) {


### PR DESCRIPTION
## 🔎 작업 내용

- MatchingProcessor 부분에서 매칭 완료 후 매칭 된 유저의 데이터를 es에서 삭제하는 로직 제거

## 🔧 앞으로의 과제

