### PR TITLE
fix/#24 ChampionInfo데이터 형식 일치화

### DIFF
--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/dto/PreferredPartnerParsingDto.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/dto/PreferredPartnerParsingDto.java
@@ -1,5 +1,9 @@
 package com.matching.ezgg.domain.matching.dto;
 
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +20,8 @@ import lombok.ToString;
 public class PreferredPartnerParsingDto {
 
 	private WantLine wantLine;
+
+	@JsonProperty("selectedChampions")
 	private ChampionInfo championInfo;
 
 	@Getter
@@ -36,7 +42,8 @@ public class PreferredPartnerParsingDto {
 	@Builder
 	@ToString
 	public static class ChampionInfo {
-		private String preferredChampion;
-		private String unpreferredChampion;
+		private List<String> preferredChampions;
+		@JsonProperty("bannedChampions")
+		private List<String> unpreferredChampions;
 	}
 }

--- a/frontend/ezgg/src/hooks/useWebSocket.js
+++ b/frontend/ezgg/src/hooks/useWebSocket.js
@@ -59,15 +59,6 @@ export const useWebSocket = ({onMessage, onConnect, onDisconnect, onError}) => {
         }
     }, [onDisconnect]);
 
-    // const sendMatchingRequest = useCallback((payload) => {
-    //   if (!stompClient.current?.connected) {
-    //     connect(() => { // 연결 보장 후 전송
-    //       stompClient.current.send('/app/matching/start', {}, JSON.stringify(payload));
-    //     });
-    //     return;
-    //   }
-    //   stompClient.current.send('/app/matching/start', {}, JSON.stringify(payload));
-    // }, [connect]);
     const sendMatchingRequest = useCallback((payload) => {
         // 필요한 데이터만 추출하여 최적화된 페이로드 생성
         const optimizedPayload = {

--- a/frontend/ezgg/src/hooks/useWebSocket.js
+++ b/frontend/ezgg/src/hooks/useWebSocket.js
@@ -1,73 +1,91 @@
-import {useRef, useCallback, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import SockJS from 'sockjs-client';
-import { Stomp } from '@stomp/stompjs';
+import {Stomp} from '@stomp/stompjs';
 
-export const useWebSocket = ({ onMessage, onConnect, onDisconnect, onError }) => {
+export const useWebSocket = ({onMessage, onConnect, onDisconnect, onError}) => {
     const stompClient = useRef(null);
     const [isConnected, setIsConnected] = useState(false);
 
     const connect = useCallback((onConnectedCallback) => {
-      if (stompClient.current && stompClient.current.connected) {
-        // 이미 연결된 경우 바로 콜백 실행
-        onConnectedCallback?.();
-        return;
-      }
-
-      const token = localStorage.getItem('token');
-      console.log("[useWebSocket.js]\ntoken: ", token);
-      const socket = new SockJS(`http://localhost:8888/ws?token=${token}`);
-      stompClient.current = Stomp.over(socket);
-
-      socket.onclose = () => {
-        setIsConnected(false);
-        if (onDisconnect) onDisconnect();
-      };
-
-      stompClient.current.connect({},
-        () => {
-          console.log("[useWebSocket.js]\nWebSocket connected");
-          setIsConnected(true);
-
-
-          // 개별 유저의 매칭 결과 구독
-          stompClient.current.subscribe(`/user/queue/matching`, (message) => {
-            const response = JSON.parse(message.body);
-            onMessage(response);
-          });
-
-          stompClient.current.subscribe(`/user/queue/error`, (message) => {
-            onError(message.body);
-          });
-
-          if (onConnect) onConnect();
-          onConnectedCallback?.();
-        },
-        (error) => {
-          console.error("WebSocket error", error);
-          setIsConnected(false);
-          if (onDisconnect) onDisconnect();
+        if (stompClient.current && stompClient.current.connected) {
+            // 이미 연결된 경우 바로 콜백 실행
+            onConnectedCallback?.();
+            return;
         }
-      );
+
+        const token = localStorage.getItem('token');
+        console.log("[useWebSocket.js]\ntoken: ", token);
+        const socket = new SockJS(`http://localhost:8888/ws?token=${token}`);
+        stompClient.current = Stomp.over(socket);
+
+        socket.onclose = () => {
+            setIsConnected(false);
+            if (onDisconnect) onDisconnect();
+        };
+
+        stompClient.current.connect({},
+            () => {
+                console.log("[useWebSocket.js]\nWebSocket connected");
+                setIsConnected(true);
+
+
+                // 개별 유저의 매칭 결과 구독
+                stompClient.current.subscribe(`/user/queue/matching`, (message) => {
+                    const response = JSON.parse(message.body);
+                    onMessage(response);
+                });
+
+                stompClient.current.subscribe(`/user/queue/error`, (message) => {
+                    onError(message.body);
+                });
+
+                if (onConnect) onConnect();
+                onConnectedCallback?.();
+            },
+            (error) => {
+                console.error("WebSocket error", error);
+                setIsConnected(false);
+                if (onDisconnect) onDisconnect();
+            }
+        );
     }, [onConnect, onMessage, onDisconnect]);
 
-  const disconnect = useCallback(() => {
-    if (stompClient.current) {
-      stompClient.current.disconnect(() => {
-        setIsConnected(false);
-        if (onDisconnect) onDisconnect();
-      });
-    }
-  }, [onDisconnect]);
+    const disconnect = useCallback(() => {
+        if (stompClient.current) {
+            stompClient.current.disconnect(() => {
+                setIsConnected(false);
+                if (onDisconnect) onDisconnect();
+            });
+        }
+    }, [onDisconnect]);
 
-  const sendMatchingRequest = useCallback((payload) => {
-    if (!stompClient.current?.connected) {
-      connect(() => { // 연결 보장 후 전송
-        stompClient.current.send('/app/matching/start', {}, JSON.stringify(payload));
-      });
-      return;
-    }
-    stompClient.current.send('/app/matching/start', {}, JSON.stringify(payload));
-  }, [connect]);
+    // const sendMatchingRequest = useCallback((payload) => {
+    //   if (!stompClient.current?.connected) {
+    //     connect(() => { // 연결 보장 후 전송
+    //       stompClient.current.send('/app/matching/start', {}, JSON.stringify(payload));
+    //     });
+    //     return;
+    //   }
+    //   stompClient.current.send('/app/matching/start', {}, JSON.stringify(payload));
+    // }, [connect]);
+    const sendMatchingRequest = useCallback((payload) => {
+        // 필요한 데이터만 추출하여 최적화된 페이로드 생성
+        const optimizedPayload = {
+            wantLine: payload.wantLine,
+            selectedChampions: {
+                preferredChampions: payload.selectedChampions?.preferredChampions?.map(champ => champ.id) || [],
+                bannedChampions: payload.selectedChampions?.bannedChampions?.map(champ => champ.id) || []
+            }
+        };
 
-  return { connect, disconnect, sendMatchingRequest, isConnected };
+        if (!stompClient.current?.connected) {
+            connect(() => { // 연결 보장 후 전송
+                stompClient.current.send('/app/matching/start', {}, JSON.stringify(optimizedPayload));
+            });
+            return;
+        }
+        stompClient.current.send('/app/matching/start', {}, JSON.stringify(optimizedPayload));
+    }, [connect]);
+
+    return {connect, disconnect, sendMatchingRequest, isConnected};
 };


### PR DESCRIPTION
## 🔎 작업 내용

- 매칭 되지 않는 문제 해결
  - 에러 이유 :
      1. 프론트에서 championInfo의 형식이 달랐음 ( Fe : 배열 ,Be : 문자열)
      2. 프론트에서 (비)선호 챔피언의 정보를 보낼때 (id,name,image) 정보를 보내 이를 id(영문명)만 보내도록 수정  

- 결과 : 매칭이 원할이 됨 ( 레디스에 리트라이 매칭도생성됨) 하지만 **새로운 문제 발생** 매칭된 유저의 카드가 0.1초 보여지고 사라짐. 해결해야함


## 🔧 앞으로의 과제

- @Setter 제거
- 0.1초만에 사라지는 매칭된 유저의 카드 에러 수정
- 에러 발생 후 매칭 취소되었을 때 처리 로직 추가 예정( 자세히 물어봐야할듯함)