### PR TITLE
Fix:#35 - 매칭 가산점(matching score) 문제 해결

### DIFF
--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/infra/es/service/EsMatchingFilter.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/infra/es/service/EsMatchingFilter.java
@@ -162,20 +162,12 @@ public class EsMatchingFilter {
 		int winRateWeight = 0; // 승률관련 가중치 정해진게 없어 0으로 처리
 
 		// 순위 가중치
-		int rankWeight;
-		switch (championRank) {
-			case 1:
-				rankWeight = 5;
-				break; // 1위는 높은 가중치
-			case 2:
-				rankWeight = 3;
-				break; // 2위는 중간 가중치
-			case 3:
-				rankWeight = 1;
-				break; // 3위는 낮은 가중치
-			default:
-				rankWeight = 0; // 나머지는 가중치 없음
-		}
+		int rankWeight = switch (championRank) {
+			case 1 -> 5; // 1위는 높은 가중치
+			case 2 -> 3; // 2위는 중간 가중치
+			case 3 -> 1; // 3위는 낮은 가중치
+			default -> 0; // 나머지는 가중치 없음
+		};
 
 		// 선호/비선호 여부에 상관없이 동일한 가중치 적용
 		// (이 부분은 비즈니스 로직에 따라 다르게 처리할 수 있음)
@@ -190,7 +182,7 @@ public class EsMatchingFilter {
 		}
 
 		return mostChampions.stream()
-			.filter(champion -> champion.getChampionName().equals(championName))
+			.filter(champion -> champion.getChampionName().equalsIgnoreCase(championName))
 			.findFirst()
 			.orElse(null);
 	}
@@ -200,7 +192,7 @@ public class EsMatchingFilter {
 		log.debug("Finding rank for: {}", championName);
 		for (int i = 0; i < mostChampions.size(); i++) {
 			log.debug("Candidate: {}", mostChampions.get(i).getChampionName());
-			if (mostChampions.get(i).getChampionName().equals(championName)) {
+			if (mostChampions.get(i).getChampionName().equalsIgnoreCase(championName)) {
 				return i + 1; // 1위부터 시작하므로 i + 1을 반환
 			}
 		}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/service/MatchingProcessor.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/service/MatchingProcessor.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.matching.ezgg.domain.matching.dto.MatchingFilterParsingDto;
 import com.matching.ezgg.domain.matching.infra.es.service.EsMatchingFilter;
+import com.matching.ezgg.domain.matching.infra.es.service.EsService;
 import com.matching.ezgg.domain.matching.infra.redis.stream.RedisStreamProducer;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class MatchingProcessor {
 
 	private final EsMatchingFilter esMatchingFilter;
 	private final RedisStreamProducer redisStreamProducer;
+	private final EsService esService;
 
 	public void tryMatch(MatchingFilterParsingDto matchingFilterParsingDto) {
 		try {
@@ -53,6 +55,10 @@ public class MatchingProcessor {
 
 			MatchingFilterParsingDto bestMatchingUser = matchingUsers.getFirst(); // 매칭 점수가 가장 높은 유저
 			log.info("매칭 성공! >>>>> {} : {}", matchingFilterParsingDto.getMemberId(), bestMatchingUser.getMemberId());
+
+			// ES에서 매칭된 유저들의 데이터 삭제
+			esService.deleteDocByMemberId(matchingFilterParsingDto.getMemberId());
+			esService.deleteDocByMemberId(bestMatchingUser.getMemberId());
 
 			redisStreamProducer.acknowledgeBothUser(matchingFilterParsingDto, bestMatchingUser);
 			redisStreamProducer.removeRetryCandidate(matchingFilterParsingDto);


### PR DESCRIPTION
## 🔎 작업 내용

- ES 제거 로직 복구
  - redis와 동일한 ES가 필요 (ES에서 조회할 때 매칭 시도하는 유저만 있는게 더 빠르고 깔끔하게 조회 가능)
- 가산점 문제 해결
  - FE에서 챔피언 이름이 "Varus" 같이 대문자가 포함되어 전달되는 경우 RecentTwentyMatchParsingDto.MostChampion에는 소문자로 조회가 안 되서 0점 처리 됨
  - equals() -> equalsIgnoreCase() : 대소문자 상관없이 동일한지 비교




## 🔧 앞으로의 과제

- FE 매칭된 결과 반영 (Result를 UserProfileCard에 전달)
- 매칭을 ES에서 조회할 때 양방향 조회해서 서로 점수가 최적의 경우로 매칭되도록 수정 필요

