### PR TITLE
fix: #52-매칭된 상대방 정보 표시 & 돌아가기 함수 추가

### DIFF
--- a/frontend/ezgg/src/components/DuoFinder/DuoFinder.jsx
+++ b/frontend/ezgg/src/components/DuoFinder/DuoFinder.jsx
@@ -21,11 +21,9 @@ const DuoFinder = (
           memberDataBundle={memberDataBundle}
           isLoading={isLoading}
         />
-
         {matchResult ? (
           <UserProfileCard
-            userInfo={userInfo}
-            memberDataBundle={memberDataBundle}
+            memberDataBundle={matchResult.data}
             isLoading={isLoading}
           />
         ) : (

--- a/frontend/ezgg/src/components/DuoFinder/user/UserProfileCard.jsx
+++ b/frontend/ezgg/src/components/DuoFinder/user/UserProfileCard.jsx
@@ -4,7 +4,7 @@ import {WinRateStats} from "./WinRateStats.jsx";
 import {LoadingSpinner} from "../../layout/LoadingSpinner.jsx";
 import styled from '@emotion/styled';
 
-export const UserProfileCard = ({ userInfo, memberDataBundle, isLoading }) => {
+export const UserProfileCard = ({ memberDataBundle, isLoading }) => {
   const { memberInfoDto, recentTwentyMatchDto } = memberDataBundle || {};
 
   return (
@@ -16,7 +16,7 @@ export const UserProfileCard = ({ userInfo, memberDataBundle, isLoading }) => {
           <ChampionGallery champions = {recentTwentyMatchDto?.championStats} />
           <ProfileInfo>
             <ProfileTitle>
-              {userInfo?.riotUsername || "사용자"} #{userInfo?.riotTag || "0000"}
+              {memberInfoDto?.riotUsername || "사용자"} #{memberInfoDto?.riotTag || "0000"}
             </ProfileTitle>
             <RankBadge
               tier={memberInfoDto?.tier}

--- a/frontend/ezgg/src/hooks/useMatchingSystem.js
+++ b/frontend/ezgg/src/hooks/useMatchingSystem.js
@@ -14,7 +14,7 @@ export const useMatchingSystem = () => {
       setMatchResult(response)
       disconnect();
     },
-    onDisconnect: () => handleMatchCancel()
+    onDisconnect: () => handleDisconnect()
     // onMessage: (response) => {
     //   console.log(response)
     //   if (response.status === 'SUCCESS') {
@@ -51,6 +51,12 @@ export const useMatchingSystem = () => {
       setMatchingCriteria(criteria);
     });
   };
+
+  const handleDisconnect = () => {
+    disconnect();
+    setIsMatching(false);
+    setMatchingCriteria(getInitialCriteria());
+  }
 
   const handleMatchCancel = () => {
     disconnect();


### PR DESCRIPTION
## 🔎 작업 내용

- 돌아가기에 맞는 새로운 함수 적용
- UserProfileCard에 매칭된 사용자 정보(memberBundle) 수정




## 🔧 앞으로의 과제

- 듀오 매칭 타임라인
- 매칭 취소 페널티

