### PR TITLE
feat/#32 chatting 및 웹소켓 연결 해제 시점 변경

### DIFF
--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/chat/controller/ChatController.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/chat/controller/ChatController.java
@@ -1,0 +1,80 @@
+package com.matching.ezgg.domain.chat.controller;
+
+import java.security.Principal;
+import java.util.List;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import com.matching.ezgg.domain.chat.dto.ChatMessageDto;
+import com.matching.ezgg.domain.chat.service.ChatRoomService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+	private final SimpMessagingTemplate messagingTemplate;
+	private final ChatRoomService chatRoomService;
+
+	/**
+	 *
+	 * @param chatMessage
+	 * @param principal
+	 */
+	@MessageMapping("/chat/send")
+	public void sendChatMessage(ChatMessageDto chatMessage, Principal principal) {
+		log.info("[INFO] 채팅 메시지 수신 - 방ID: {}, 발신자: {}, 메시지: {}",
+			chatMessage.getChattingRoomId(), chatMessage.getSender(), chatMessage.getMessage());
+
+		// 🔥 Principal 정보 확인
+		log.info("[DEBUG] Principal 정보: {}", principal != null ? principal.getName() : "null");
+
+		List<String> participants = chatRoomService.getParticipants(chatMessage.getChattingRoomId());
+
+		if (participants.isEmpty()) {
+			log.warn("[WARN] 채팅방에 참가자가 없습니다. 발신자를 추가합니다");
+			chatRoomService.addParticipant(chatMessage.getChattingRoomId(), chatMessage.getSender());
+
+			// 🔥 Principal 이름도 추가 (백업)
+			if (principal != null && !principal.getName().equals(chatMessage.getSender())) {
+				log.info("[INFO] Principal 이름도 참가자로 추가: {}", principal.getName());
+				chatRoomService.addParticipant(chatMessage.getChattingRoomId(), principal.getName());
+			}
+
+			participants = chatRoomService.getParticipants(chatMessage.getChattingRoomId());
+		}
+
+		log.info("[INFO] 참가자 목록: {}", participants);
+
+		// 🔥 Principal 이름으로도 전송 (백업)
+		if (principal != null) {
+			messagingTemplate.convertAndSendToUser(
+				principal.getName(),
+				"/queue/" + chatMessage.getChattingRoomId(),
+				chatMessage
+			);
+			log.info("[INFO] Principal로 메시지 전송됨 - 수신자: {}", principal.getName());
+		}
+
+		// 브로드캐스트는 확실히 작동해야 함
+		messagingTemplate.convertAndSend("/topic/chat/" + chatMessage.getChattingRoomId(), chatMessage);
+		log.info("[INFO] 브로드캐스트 메시지 전송됨");
+
+		for (String participantId : participants) {
+			messagingTemplate.convertAndSendToUser(
+				participantId,
+				"/queue/" + chatMessage.getChattingRoomId(),
+				chatMessage
+			);
+			log.info("[INFO] 개별 메시지 전송됨 - 수신자: {}", participantId);
+		}
+	}
+}
+
+
+

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/chat/controller/ChatController.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/chat/controller/ChatController.java
@@ -4,6 +4,7 @@ import java.security.Principal;
 import java.util.List;
 
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
@@ -27,12 +28,9 @@ public class ChatController {
 	 * @param principal
 	 */
 	@MessageMapping("/chat/send")
-	public void sendChatMessage(ChatMessageDto chatMessage, Principal principal) {
+	public void sendChatMessage(@Payload ChatMessageDto chatMessage, Principal principal) {
 		log.info("[INFO] 채팅 메시지 수신 - 방ID: {}, 발신자: {}, 메시지: {}",
 			chatMessage.getChattingRoomId(), chatMessage.getSender(), chatMessage.getMessage());
-
-		// 🔥 Principal 정보 확인
-		log.info("[DEBUG] Principal 정보: {}", principal != null ? principal.getName() : "null");
 
 		List<String> participants = chatRoomService.getParticipants(chatMessage.getChattingRoomId());
 
@@ -40,7 +38,7 @@ public class ChatController {
 			log.warn("[WARN] 채팅방에 참가자가 없습니다. 발신자를 추가합니다");
 			chatRoomService.addParticipant(chatMessage.getChattingRoomId(), chatMessage.getSender());
 
-			// 🔥 Principal 이름도 추가 (백업)
+			//Principal 이름도 추가 (백업)
 			if (principal != null && !principal.getName().equals(chatMessage.getSender())) {
 				log.info("[INFO] Principal 이름도 참가자로 추가: {}", principal.getName());
 				chatRoomService.addParticipant(chatMessage.getChattingRoomId(), principal.getName());
@@ -51,7 +49,7 @@ public class ChatController {
 
 		log.info("[INFO] 참가자 목록: {}", participants);
 
-		// 🔥 Principal 이름으로도 전송 (백업)
+		//Principal 이름으로도 전송 (백업)
 		if (principal != null) {
 			messagingTemplate.convertAndSendToUser(
 				principal.getName(),

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/chat/dto/ChatMessageDto.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/chat/dto/ChatMessageDto.java
@@ -1,0 +1,17 @@
+package com.matching.ezgg.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageDto {
+	private String chattingRoomId;
+	private String message;
+	private String sender;
+	private String timestamp;
+}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/chat/service/ChatRoomService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,90 @@
+package com.matching.ezgg.domain.chat.service;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class ChatRoomService {
+
+	// 채팅방 ID → 참여자 리스트 (유저 ID or username)
+	private final ConcurrentHashMap<String, CopyOnWriteArrayList<String>> chatRoomParticipants = new ConcurrentHashMap<>();
+
+	/**
+	 * 채팅방에 참여자 추가
+	 * @param chattingRoomId 채팅방 ID
+	 * @param memberId 참여자 ID (유저 ID 또는 username)
+	 */
+	public void addParticipant(String chattingRoomId, String memberId) {
+		if (chattingRoomId == null || memberId == null) {
+			log.warn("[WARN] 채팅방 ID 또는 멤버 ID가 null입니다. chattingRoomId: {}, memberId: {}", chattingRoomId, memberId);
+			return;
+		}
+
+		chatRoomParticipants
+			.computeIfAbsent(chattingRoomId, key -> new CopyOnWriteArrayList<>())
+			.addIfAbsent(memberId);
+
+		log.info("[INFO] 채팅방 참여자 추가됨 - 방ID: {}, 멤버ID: {}, 현재 참여자 수: {}",
+			chattingRoomId, memberId, getParticipantCount(chattingRoomId));
+	}
+
+	/**
+	 * 채팅방에서 참여자 제거
+	 * @param chattingRoomId 채팅방 ID
+	 * @param memberId 참여자 ID
+	 */
+	public void removeParticipant(String chattingRoomId, String memberId) {
+		if (chattingRoomId == null || memberId == null) {
+			log.warn("[WARN] 채팅방 ID 또는 멤버 ID가 null입니다. chattingRoomId: {}, memberId: {}", chattingRoomId, memberId);
+			return;
+		}
+
+		List<String> participants = chatRoomParticipants.get(chattingRoomId);
+		if (participants != null) {
+			boolean removed = participants.remove(memberId);
+			if (removed) {
+				log.info("[INFO] 채팅방 참여자 제거됨 - 방ID: {}, 멤버ID: {}, 현재 참여자 수: {}",
+					chattingRoomId, memberId, participants.size());
+
+				// 참여자가 모두 나가면 채팅방 정보 삭제
+				if (participants.isEmpty()) {
+					chatRoomParticipants.remove(chattingRoomId);
+					log.info("[INFO] 채팅방 삭제됨 - 방ID: {} (참여자 0명)", chattingRoomId);
+				}
+			}
+		}
+	}
+
+	/**
+	 * 채팅방 참여자 목록 반환
+	 * @param chattingRoomId 채팅방 ID
+	 * @return 참여자 ID 리스트
+	 */
+	public List<String> getParticipants(String chattingRoomId) {
+		if (chattingRoomId == null) {
+			log.warn("[INFO] 채팅방 ID가 null입니다.");
+			return new CopyOnWriteArrayList<>();
+		}
+
+		List<String> participants = chatRoomParticipants.getOrDefault(chattingRoomId, new CopyOnWriteArrayList<>());
+		log.debug("[INFO] 채팅방 참여자 조회 - 방ID: {}, 참여자 수: {}, 참여자 목록: {}",
+			chattingRoomId, participants.size(), participants);
+
+		return participants;
+	}
+
+	/**
+	 * 채팅방 참여자 수 반환
+	 * @param chattingRoomId 채팅방 ID
+	 * @return 참여자 수
+	 */
+	public int getParticipantCount(String chattingRoomId) {
+		return getParticipants(chattingRoomId).size();
+	}
+}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/chat/service/ChatRoomService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/chat/service/ChatRoomService.java
@@ -68,12 +68,12 @@ public class ChatRoomService {
 	 */
 	public List<String> getParticipants(String chattingRoomId) {
 		if (chattingRoomId == null) {
-			log.warn("[INFO] 채팅방 ID가 null입니다.");
+			log.warn("[WARN] 채팅방 ID가 null입니다.");
 			return new CopyOnWriteArrayList<>();
 		}
 
 		List<String> participants = chatRoomParticipants.getOrDefault(chattingRoomId, new CopyOnWriteArrayList<>());
-		log.debug("[INFO] 채팅방 참여자 조회 - 방ID: {}, 참여자 수: {}, 참여자 목록: {}",
+		log.info("[INFO] 채팅방 참여자 조회 - 방ID: {}, 참여자 수: {}, 참여자 목록: {}",
 			chattingRoomId, participants.size(), participants);
 
 		return participants;

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/dto/MatchingSuccessResponse.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/dto/MatchingSuccessResponse.java
@@ -21,5 +21,6 @@ public class MatchingSuccessResponse {
 		private Long matchedMemberId;
 		private MemberInfoDto memberInfoDto;
 		private RecentTwentyMatchDto recentTwentyMatchDto;
+		private String chattingRoomId;
 	}
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/dto/MatchingSuccessResponse.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/dto/MatchingSuccessResponse.java
@@ -3,19 +3,16 @@ package com.matching.ezgg.domain.matching.dto;
 import com.matching.ezgg.domain.memberInfo.dto.MemberInfoDto;
 import com.matching.ezgg.domain.recentTwentyMatch.dto.RecentTwentyMatchDto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 @Builder
 public class MatchingSuccessResponse {
 	private String status;
 	private MatchedMemberData data;
 
 	@Getter
-	@AllArgsConstructor
 	@Builder
 	public static class MatchedMemberData {
 		private Long matchedMemberId;

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/infra/redis/service/RedisService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/infra/redis/service/RedisService.java
@@ -92,22 +92,25 @@ public class RedisService {
 		}
 	}
 
-	private MatchingSuccessResponse getMatchingSuccessResponse(Long matchedMemberId) {
+	private MatchingSuccessResponse getMatchingSuccessResponse(Long matchedMemberId, String chattingRoomId) {
 		MemberDataBundleDto data = memberDataBundleService.getMemberDataBundleByMemberId(matchedMemberId);
+
+		log.info("매칭 성공! >>>>> : {}, 매칭된 방번호 : {}", matchedMemberId, chattingRoomId);
 
 		return MatchingSuccessResponse.builder()
 			.status("SUCCESS")
 			.data(MatchingSuccessResponse.MatchedMemberData.builder()
 				.matchedMemberId(matchedMemberId)
 				.memberInfoDto(data.getMemberInfoDto())
+				.chattingRoomId(chattingRoomId)
 				.recentTwentyMatchDto(data.getRecentTwentyMatchDto())
 				.build())
 			.build();
 	}
 
-	public void sendMatchingSuccessResponse(Long memberId, Long matchedMemberId) {
+	public void sendMatchingSuccessResponse(Long memberId, Long matchedMemberId, String chattingRoomId) {
 		messagingTemplate.convertAndSendToUser(memberId.toString(), "/queue/matching",
-			getMatchingSuccessResponse(matchedMemberId));
+			getMatchingSuccessResponse(matchedMemberId, chattingRoomId));
 	}
 
 	public void retryMatchRequest(MatchingFilterParsingDto matchingFilterParsingDto) {

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/infra/redis/service/RedisService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/infra/redis/service/RedisService.java
@@ -56,7 +56,7 @@ public class RedisService {
 				RecordId recordId = redisTemplate.opsForStream().add(RedisKey.STREAM_KEY.getValue(), message);
 				redisTemplate.opsForHash().put(RedisKey.STREAM_ID_HASH_KEY.getValue(), memberId, recordId.getValue());
 
-				log.info("Redis Stream 및 es 매칭 요청 저장 완료 : {}", matchingFilterParsingDto.getMemberId());
+				log.info("[INFO] Redis Stream 및 es 매칭 요청 저장 완료 : {}", matchingFilterParsingDto.getMemberId());
 			}
 		} catch (JsonProcessingException e) {
 			throw new RuntimeException("Stream 등록 실패", e);
@@ -90,14 +90,14 @@ public class RedisService {
 				redisTemplate.opsForHash().delete(RedisKey.STREAM_ID_HASH_KEY.getValue(), memberIdStr);
 			}
 		} catch (Exception e) {
-			log.error("Stream 처리 중 에러 발생 : {}", e.getMessage());
+			log.error("[ERROR] Stream 처리 중 에러 발생 : {}", e.getMessage());
 		}
 	}
 
 	private MatchingSuccessResponse getMatchingSuccessResponse(Long matchedMemberId, String chattingRoomId) {
 		MemberDataBundleDto data = memberDataBundleService.getMemberDataBundleByMemberId(matchedMemberId);
 
-		log.info("매칭 성공! >>>>> : {}, 매칭된 방번호 : {}", matchedMemberId, chattingRoomId);
+		log.info("[INFO] 매칭 성공! >>>>> : {}, 매칭된 방번호 : {}", matchedMemberId, chattingRoomId);
 
 		return MatchingSuccessResponse.builder()
 			.status("SUCCESS")
@@ -129,17 +129,17 @@ public class RedisService {
 						if (existingDto.getMemberId().equals(matchingFilterParsingDto.getMemberId())) {
 							// 동일한 유저의 데이터가 있는 경우, 변경 여부 확인
 							if (isDataEqual(existingDto, matchingFilterParsingDto)) {
-								log.info("동일한 매칭 요청이 이미 retry 큐에 존재합니다. 업데이트하지 않습니다. : {}", memberId);
+								log.info("[INFO] 동일한 매칭 요청이 이미 retry 큐에 존재합니다. 업데이트하지 않습니다. : {}", memberId);
 								return;
 							}
 
 							// 데이터가 다른 경우 기존 데이터 삭제
 							removeRetryCandidate(json);
-							log.info("기존 retry 데이터 삭제 완료 : {}", memberId);
+							log.info("[INFO] 기존 retry 데이터 삭제 완료 : {}", memberId);
 							break;
 						}
 					} catch (JsonProcessingException e) {
-						log.error("Retry 큐 데이터 파싱 실패 : {}", e.getMessage());
+						log.error("[ERROR] Retry 큐 데이터 파싱 실패 : {}", e.getMessage());
 					}
 				}
 			}
@@ -150,152 +150,156 @@ public class RedisService {
 			long delay = retryTime - System.currentTimeMillis(); // 실제 남은 시간 계산
 
 			redisTemplate.opsForZSet().add(RedisKey.RETRY_ZSET_KEY.getValue(), json, retryTime);
-			log.info("딜레이 큐에 등록 완료 ({}초 후 재시도 예정) : {}", delay / 1000, memberId);
+			log.info("[INFO] 딜레이 큐에 등록 완료 ({}초 후 재시도 예정) : {}", delay / 1000, memberId);
 		} catch (JsonProcessingException e) {
-			log.error("딜레이 큐 등록 실패 : {}", e.getMessage());
+			log.error("[INFO] 딜레이 큐 등록 실패 : {}", e.getMessage());
 		}
 	}
 
 	public void createStringGroup() {
 		stringRedisTemplate.opsForStream().createGroup(
 			RedisKey.STREAM_KEY.getValue(), ReadOffset.latest(), RedisKey.STREAM_GROUP.getValue());
-    }
+	}
 
-    public List<MapRecord<String, Object, Object>> getStringGroup() {
-        return stringRedisTemplate.opsForStream().read(
-            Consumer.from(RedisKey.STREAM_GROUP.getValue(), RedisKey.CONSUMER_NAME.getValue()),
-            StreamReadOptions.empty().count(5).block(Duration.ofMillis(2000)),
-            StreamOffset.create(RedisKey.STREAM_KEY.getValue(), ReadOffset.lastConsumed()));
-    }
+	public List<MapRecord<String, Object, Object>> getStringGroup() {
+		return stringRedisTemplate.opsForStream().read(
+			Consumer.from(RedisKey.STREAM_GROUP.getValue(), RedisKey.CONSUMER_NAME.getValue()),
+			StreamReadOptions.empty().count(5).block(Duration.ofMillis(2000)),
+			StreamOffset.create(RedisKey.STREAM_KEY.getValue(), ReadOffset.lastConsumed()));
+	}
 
-    public Set<String> getRetryCandidates() {
-        long now = System.currentTimeMillis();
-        return redisTemplate.opsForZSet().rangeByScore(RedisKey.RETRY_ZSET_KEY.getValue(), 0, now);
-    }
-  
-    public Set<String> getAllCandidates() {
-      return redisTemplate.opsForZSet().range(RedisKey.RETRY_ZSET_KEY.getValue(), 0, -1);
-    }
+	public Set<String> getRetryCandidates() {
+		long now = System.currentTimeMillis();
+		return redisTemplate.opsForZSet().rangeByScore(RedisKey.RETRY_ZSET_KEY.getValue(), 0, now);
+	}
 
-    public void removeRetryCandidate(String json) {
-        redisTemplate.opsForZSet().remove(RedisKey.RETRY_ZSET_KEY.getValue(), json);
-    }
-  
-    // 사용자 id를 활용하여 Redis Stream과 ZSet에서 제거합니다.
-    public void removeMemberFromAllRedisKeys(Long memberId) {
-      acknowledgeMatch(memberId); // Stream 삭제 및 ack 처리
-      removeRetryCandidateByMemberId(memberId); // ZSet 삭제
-    }
+	public Set<String> getAllCandidates() {
+		return redisTemplate.opsForZSet().range(RedisKey.RETRY_ZSET_KEY.getValue(), 0, -1);
+	}
 
-    // 리트라이 큐에서 사용자id를 활용하여 제거합니다.
-    public void removeRetryCandidateByMemberId(Long memberId) {
-      // 모든 시점의 리트라이 큐 데이터 가져오기(매칭 시도중 새로고침하고 매칭을 시도했을때 업데이트 되지 않는 문제 해결을 위해)
-      Set<String> retryCandidates = getAllCandidates();
+	public void removeRetryCandidate(String json) {
+		redisTemplate.opsForZSet().remove(RedisKey.RETRY_ZSET_KEY.getValue(), json);
+	}
 
-      if (retryCandidates != null) {
-        for (String json : retryCandidates) {
-          try {
-            MatchingFilterParsingDto existingDto = objectMapper.readValue(json, MatchingFilterParsingDto.class);
-            if (existingDto.getMemberId().equals(memberId)) {
-              removeRetryCandidate(json); // 해당 JSON 삭제
-              log.info("기존 retry 데이터 삭제 완료 : {}", memberId);
-            }
-          } catch (JsonProcessingException e) {
-            log.error("Retry 큐 데이터 파싱 실패 : {}", e.getMessage());
-          }
-        }
-      }
-    }
+	// 사용자 id를 활용하여 Redis Stream과 ZSet에서 제거합니다.
+	public void removeMemberFromAllRedisKeys(Long memberId) {
+		acknowledgeMatch(memberId); // Stream 삭제 및 ack 처리
+		removeRetryCandidateByMemberId(memberId); // ZSet 삭제
+	}
 
-    //딜리트 큐에 사용자를 추가합니다.
-    public void addToDeleteQueue(Long memberId) {
-      try {
-        redisTemplate.opsForSet().add(RedisKey.DELETE_QUEUE_KEY.getValue(), memberId.toString());
-        // 딜리트 큐에서 ttl 설정
-        redisTemplate.expire(RedisKey.DELETE_QUEUE_KEY.getValue(), Duration.ofSeconds(15));
-        log.info("사용자 ID {}가 딜리트 큐에 추가되었습니다.", memberId);
-      } catch (Exception e) {
-        log.error("Redis에서 딜리트 큐에 오류 발생: {}", e.getMessage());
-        throw new RuntimeException("매칭 취소 처리 중 오류가 발생했습니다.", e);
-      }
-    }
+	// 리트라이 큐에서 사용자id를 활용하여 제거합니다.
+	public void removeRetryCandidateByMemberId(Long memberId) {
+		// 모든 시점의 리트라이 큐 데이터 가져오기(매칭 시도중 새로고침하고 매칭을 시도했을때 업데이트 되지 않는 문제 해결을 위해)
+		Set<String> retryCandidates = getAllCandidates();
 
-    // 딜리트 큐에 사용자가 있는지 확인합니다.
-    public boolean isInDeleteQueue(Long memberId) {
-      Boolean isMember = redisTemplate.opsForSet()
-        .isMember(RedisKey.DELETE_QUEUE_KEY.getValue(), memberId.toString());
-      return Boolean.TRUE.equals(isMember);
-    }
+		if (retryCandidates != null) {
+			for (String json : retryCandidates) {
+				try {
+					MatchingFilterParsingDto existingDto = objectMapper.readValue(json, MatchingFilterParsingDto.class);
+					if (existingDto.getMemberId().equals(memberId)) {
+						removeRetryCandidate(json); // 해당 JSON 삭제
+						log.info("[INFO] 기존 retry 데이터 삭제 완료 : {}", memberId);
+					}
+				} catch (JsonProcessingException e) {
+					log.error("[ERROR] Retry 큐 데이터 파싱 실패 : {}", e.getMessage());
+				}
+			}
+		}
+	}
 
-    // 딜리트 큐에서 사용자를 제거합니다.
-    public void deleteMemberToDeleteQueue(Long memberId) {
-      redisTemplate.opsForSet().remove(RedisKey.DELETE_QUEUE_KEY.getValue(), memberId.toString());
-    }
+	//딜리트 큐에 사용자를 추가합니다.
+	public void addToDeleteQueue(Long memberId) {
+		try {
+			redisTemplate.opsForSet().add(RedisKey.DELETE_QUEUE_KEY.getValue(), memberId.toString());
+			// 딜리트 큐에서 ttl 설정
+			redisTemplate.expire(RedisKey.DELETE_QUEUE_KEY.getValue(), Duration.ofSeconds(15));
+			log.info("[INFO] 사용자 ID {}가 딜리트 큐에 추가되었습니다.", memberId);
+		} catch (Exception e) {
+			log.error("[ERROR] Redis에서 딜리트 큐에 오류 발생: {}", e.getMessage());
+			throw new RuntimeException("매칭 취소 처리 중 오류가 발생했습니다.", e);
+		}
+	}
 
-    public void addToMatchedUsers(Long memberId1, Long memberId2) {
-      try {
-        String timestamp = String.valueOf(System.currentTimeMillis());
-        Map<String, String> matchedData = new HashMap<>();
-        matchedData.put("memberId1", String.valueOf(memberId1));
-        matchedData.put("memberId2", String.valueOf(memberId2));
-        matchedData.put("timestamp", timestamp);
+	// 딜리트 큐에 사용자가 있는지 확인합니다.
+	public boolean isInDeleteQueue(Long memberId) {
+		Boolean isMember = redisTemplate.opsForSet()
+			.isMember(RedisKey.DELETE_QUEUE_KEY.getValue(), memberId.toString());
+		return Boolean.TRUE.equals(isMember);
+	}
 
-        String json = objectMapper.writeValueAsString(matchedData);
+	// 딜리트 큐에서 사용자를 제거합니다.
+	public void deleteMemberToDeleteQueue(Long memberId) {
+		redisTemplate.opsForSet().remove(RedisKey.DELETE_QUEUE_KEY.getValue(), memberId.toString());
+	}
 
-        redisTemplate.opsForZSet().add(RedisKey.MATCHED_ZSET_KEY.getValue(), json, Long.parseLong(timestamp));
-      } catch (Exception e) {
-        log.error("Redis에 매칭된 유저 추가 실패: {}", e.getMessage());
-      }
-    }
+	public void addToMatchedUsers(Long memberId1, Long memberId2) {
+		try {
+			String timestamp = String.valueOf(System.currentTimeMillis());
+			Map<String, String> matchedData = new HashMap<>();
+			matchedData.put("memberId1", String.valueOf(memberId1));
+			matchedData.put("memberId2", String.valueOf(memberId2));
+			matchedData.put("timestamp", timestamp);
 
-    public List<Map<String, String>> getTwentyMatchedUsers() {
-      long now = System.currentTimeMillis();
-      long threshold = now - 1000 * 60 * 20; // 20분 전
+			String json = objectMapper.writeValueAsString(matchedData);
 
-      Set<String> matchedUsers = redisTemplate.opsForZSet()
-        .rangeByScore(RedisKey.MATCHED_ZSET_KEY.getValue(), 0, threshold);
+			redisTemplate.opsForZSet().add(RedisKey.MATCHED_ZSET_KEY.getValue(), json, Long.parseLong(timestamp));
+		} catch (Exception e) {
+			log.error("[ERROR] Redis에 매칭된 유저 추가 실패: {}", e.getMessage());
+		}
+	}
 
-      if (matchedUsers == null || matchedUsers.isEmpty()) {
-        return Collections.emptyList();
-      }
+	public List<Map<String, String>> getTwentyMatchedUsers() {
+		long now = System.currentTimeMillis();
+		long threshold = now - 1000 * 60 * 20; // 20분 전
 
-      List<Map<String, String>> result = new ArrayList<>();
+		Set<String> matchedUsers = redisTemplate.opsForZSet()
+			.rangeByScore(RedisKey.MATCHED_ZSET_KEY.getValue(), 0, threshold);
 
-      for (String json : matchedUsers) {
-        try {
-          Map<String, String> matchedData = objectMapper.readValue(json, Map.class);
-          result.add(matchedData);
-        } catch (JsonProcessingException e) {
-          log.error("매칭된 유저 데이터 파싱 실패: {}", e.getMessage());
-        }
-      }
-      return result;
-    }
+		if (matchedUsers == null || matchedUsers.isEmpty()) {
+			return Collections.emptyList();
+		}
 
-    public void updateMatchedUser(Map<String, String> json, Map<String, String> updateJson) {
-      try {
-        redisTemplate.opsForZSet().remove(RedisKey.MATCHED_ZSET_KEY.getValue(), objectMapper.writeValueAsString(json));
-        redisTemplate.opsForZSet().add(RedisKey.MATCHED_ZSET_KEY.getValue(), objectMapper.writeValueAsString(updateJson), System.currentTimeMillis());
-      } catch (Exception e) {
-        log.error("Redis에 매칭된 유저 업데이트 실패: {}", e.getMessage());
-      }
-    }
+		List<Map<String, String>> result = new ArrayList<>();
 
-    public void deleteMatchedUser(Map<String, String> deleteJson) {
-      try {
-        redisTemplate.opsForZSet().remove(RedisKey.MATCHED_ZSET_KEY.getValue(), objectMapper.writeValueAsString(deleteJson));
-      } catch (Exception e) {
-        log.error("Redis에 매칭된 유저 삭제 실패: {}", e.getMessage());
-      }
-    }
+		for (String json : matchedUsers) {
+			try {
+				Map<String, String> matchedData = objectMapper.readValue(json, Map.class);
+				result.add(matchedData);
+			} catch (JsonProcessingException e) {
+				log.error("[ERROR] 매칭된 유저 데이터 파싱 실패: {}", e.getMessage());
+			}
+		}
+		return result;
+	}
 
-    public boolean canExecuteReview(Long memberId1, Long memberId2) {
-      String key = "canExecuteReview:" + memberId1 + ":" + memberId2;
-      Long count = redisTemplate.opsForValue().increment(key);
-      if(count == 1) {
-        // 최초 실행일경우
-        redisTemplate.expire(key, Duration.ofHours(2)); // 2시간 후 만료
-      }
-      return count <= 3; // 3회까지 허용
-    }
+	public void updateMatchedUser(Map<String, String> json, Map<String, String> updateJson) {
+		try {
+			redisTemplate.opsForZSet()
+				.remove(RedisKey.MATCHED_ZSET_KEY.getValue(), objectMapper.writeValueAsString(json));
+			redisTemplate.opsForZSet()
+				.add(RedisKey.MATCHED_ZSET_KEY.getValue(), objectMapper.writeValueAsString(updateJson),
+					System.currentTimeMillis());
+		} catch (Exception e) {
+			log.error("[ERROR] Redis에 매칭된 유저 업데이트 실패: {}", e.getMessage());
+		}
+	}
+
+	public void deleteMatchedUser(Map<String, String> deleteJson) {
+		try {
+			redisTemplate.opsForZSet()
+				.remove(RedisKey.MATCHED_ZSET_KEY.getValue(), objectMapper.writeValueAsString(deleteJson));
+		} catch (Exception e) {
+			log.error("[ERROR] Redis에 매칭된 유저 삭제 실패: {}", e.getMessage());
+		}
+	}
+
+	public boolean canExecuteReview(Long memberId1, Long memberId2) {
+		String key = "canExecuteReview:" + memberId1 + ":" + memberId2;
+		Long count = redisTemplate.opsForValue().increment(key);
+		if (count == 1) {
+			// 최초 실행일경우
+			redisTemplate.expire(key, Duration.ofHours(2)); // 2시간 후 만료
+		}
+		return count <= 3; // 3회까지 허용
+	}
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/infra/redis/stream/RedisStreamProducer.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/matching/infra/redis/stream/RedisStreamProducer.java
@@ -1,5 +1,7 @@
 package com.matching.ezgg.domain.matching.infra.redis.stream;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -33,8 +35,11 @@ public class RedisStreamProducer {
 	public void acknowledgeBothUser(MatchingFilterParsingDto member1, MatchingFilterParsingDto member2) {
 		redisService.acknowledgeMatch(member1.getMemberId());
 		redisService.acknowledgeMatch(member2.getMemberId());
-		redisService.sendMatchingSuccessResponse(member1.getMemberId(), member2.getMemberId());
-		redisService.sendMatchingSuccessResponse(member2.getMemberId(), member1.getMemberId());
+		
+		String chattingRoomId = UUID.randomUUID().toString();
+
+		redisService.sendMatchingSuccessResponse(member1.getMemberId(), member2.getMemberId(), chattingRoomId);
+		redisService.sendMatchingSuccessResponse(member2.getMemberId(), member1.getMemberId(), chattingRoomId);
 	}
 
 	public void retryLater(MatchingFilterParsingDto matchingFilterParsingDto) {

--- a/frontend/ezgg/src/App.jsx
+++ b/frontend/ezgg/src/App.jsx
@@ -1,5 +1,5 @@
-import React,{ useState, useEffect } from 'react';
-import { BrowserRouter as Router, Routes, Route, Link, Navigate, useLocation } from 'react-router-dom';
+import React, {useEffect, useState} from 'react';
+import {BrowserRouter as Router, Link, Navigate, Route, Routes, useLocation} from 'react-router-dom';
 import styled from '@emotion/styled';
 import api from './utils/api';
 import DuoFinder from './components/DuoFinder/DuoFinder'
@@ -7,314 +7,352 @@ import Login from './components/auth/Login';
 import Join from './components/auth/Join';
 import {useMatchingSystem} from "./hooks/useMatchingSystem.js";
 import {MatchingButtonPanel} from "./components/DuoFinder/matching/MatchingButtonPanel.jsx";
+import {useWebSocket} from './hooks/useWebSocket'; // 경로는 실제 위치에 따라 조정
+
 
 // 로그인 상태에 따라 리다이렉트하는 보호된 라우트 컴포넌트
-const ProtectedRoute = ({ element, isLoggedIn }) => {
-  const location = useLocation();
+const ProtectedRoute = ({element, isLoggedIn}) => {
+    const location = useLocation();
 
-  // 현재 위치가 /login 페이지이면서 이미 로그인 상태라면 홈으로 리다이렉트
-  if (location.pathname === '/login' && isLoggedIn) {
-    return <Navigate to="/" replace />;
-  }
-  
-  // 로그인이 필요한 페이지이고 로그인되지 않은 경우 로그인 페이지로 리다이렉트
-  if (!isLoggedIn) {
-    console.log('로그인되지 않음, 로그인 페이지로 리다이렉트');
-    return <Navigate to="/login" state={{ from: location }} replace />;
-  }
-  
-  // 로그인 상태이면 요청한 페이지 렌더링
-  return element;
+    // 현재 위치가 /login 페이지이면서 이미 로그인 상태라면 홈으로 리다이렉트
+    if (location.pathname === '/login' && isLoggedIn) {
+        return <Navigate to="/" replace/>;
+    }
+
+    // 로그인이 필요한 페이지이고 로그인되지 않은 경우 로그인 페이지로 리다이렉트
+    if (!isLoggedIn) {
+        console.log('로그인되지 않음, 로그인 페이지로 리다이렉트');
+        return <Navigate to="/login" state={{from: location}} replace/>;
+    }
+
+    // 로그인 상태이면 요청한 페이지 렌더링
+    return element;
 };
 
 const App = () => {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [userInfo, setUserInfo] = useState({
-    riotUsername: '',
-    riotTag: ''
-  });
-  const [memberDataBundle, setMemberDataBundle] = useState(null);
-  const [userDataLoading, setUserDataLoading] = useState(true);
-  const [isLoggingOut, setIsLoggingOut] = useState(false);
-  const {
-    matchResult,
-    setMatchResult,
-    matchingCriteria,
-    setMatchingCriteria,
-    isMatching,
-    handleMatchStart,
-    handleMatchCancel
-  } = useMatchingSystem();
-
-  // 앱 시작 시 로컬 스토리지에서 토큰을 확인하여 로그인 상태 유지
-  useEffect(() => {
-    const token = localStorage.getItem('token');
-    if (token) {
-      console.log('토큰 발견, 자동 로그인 시도');
-      // 토큰이 있으면 우선 로그인 상태로 설정하고 사용자 정보 요청
-      setIsLoggedIn(true);
-      fetchUserInfo();
-    } else {
-      setUserDataLoading(false);
-    }
-  }, []);
-
-  // 토큰을 사용하여 사용자 정보 가져오기
-  const fetchUserInfo = async () => {
-    setUserDataLoading(true);
-    try {
-      console.log('사용자 정보 요청 중...');
-      // 첫 번째 API 요청: 기본 사용자 정보
-      const memberInfoResponse = await api.get('/auth/memberinfo');
-      console.log('사용자 정보 API 응답:', memberInfoResponse);
-      
-      // 기본 사용자 정보 설정
-      if (memberInfoResponse.data && memberInfoResponse.data.data) {
-        console.log('기본 사용자 정보 가져오기 성공:', memberInfoResponse.data.data);
-        setUserInfo({
-          riotUsername: memberInfoResponse.data.data.riotUsername || '사용자',
-          riotTag: memberInfoResponse.data.data.riotTag || 'KR'
-        });
-        
-        try {
-          // 두 번째 API 요청: 추가 사용자 데이터 번들 (첫 번째 요청 성공 시에만)
-          const dataBundleResponse = await api.get('/auth/memberdatabundle');
-          console.log('데이터 번들 API 응답:', dataBundleResponse);
-          
-          // 추가 데이터가 있으면 저장
-          if (dataBundleResponse.data && dataBundleResponse.data.data) {
-            console.log('사용자 데이터 번들 가져오기 성공:', dataBundleResponse.data.data);
-            setMemberDataBundle(dataBundleResponse.data.data);
-          }
-        } catch (bundleError) {
-          // 데이터 번들 요청 실패 - 로그만 남기고 기본 사용자 정보는 유지
-          console.error('사용자 데이터 번들 가져오기 실패:', bundleError);
-          // 401/403 오류가 아닌 경우 무시하고 계속 진행
-          if (!(bundleError.response && 
-              (bundleError.response.status === 401 || bundleError.response.status === 403))) {
-            // 401/403이 아닌 다른 오류는 무시
-          }
-        }
-      }
-    } catch (error) {
-      console.error('사용자 정보 가져오기 실패:', error);
-    } finally {
-      setUserDataLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (userInfo) {
-      console.log('userInfo 변경됨:', userInfo);
-    }
-  }, [userInfo]);
-
-  // 로그아웃 함수
-  const handleLogout = async () => {
-    console.log('로그아웃 처리 시작');
-    setIsLoggingOut(true);
-    
-    try {
-      // 토큰 가져오기
-      const token = localStorage.getItem('token');
-      
-      if (!token) {
-        console.warn('토큰이 없습니다. 로컬에서만 로그아웃합니다.');
-      } else {
-        // 백엔드 로그아웃 API 호출 (인터셉터가 자동으로 토큰을 헤더에 추가)
-        const response = await api.post('/auth/logout');
-        console.log('서버 로그아웃 응답 상태:', response.status);
-        console.log('서버 로그아웃 성공:', response.data);
-      }
-    } catch (error) {
-      console.error('서버 로그아웃 실패:', error);
-      if (error.response) {
-        console.error('응답 상태:', error.response.status);
-        console.error('응답 데이터:', error.response.data);
-      }
-      // 서버 로그아웃에 실패하더라도 클라이언트 측 로그아웃은 진행
-    } finally {
-      // 로컬 스토리지에서 토큰 제거
-      localStorage.removeItem('token');
-      
-      // 상태 초기화
-      setIsLoggedIn(false);
-      setUserInfo({
+    const [isLoggedIn, setIsLoggedIn] = useState(false);
+    const [userInfo, setUserInfo] = useState({
         riotUsername: '',
         riotTag: ''
-      });
-      setMemberDataBundle(null);
-      
-      console.log('로그아웃 처리 완료');
-      setIsLoggingOut(false);
-    }
-  };
+    });
+    const [memberDataBundle, setMemberDataBundle] = useState(null);
+    const [userDataLoading, setUserDataLoading] = useState(true);
+    const [isLoggingOut, setIsLoggingOut] = useState(false);
 
-  return (
-    <Router>
-      <AppContainer>
-        <Header>
-          <a href="/">
-          <Logo>
-            <LogoIcon>
-              <svg viewBox="0 0 24 24">
-                <path d="M21.58,16.09l-1.09-7.66C20.21,6.46,18.52,5,16.53,5H7.47C5.48,5,3.79,6.46,3.51,8.43l-1.09,7.66 C2.2,17.63,3.39,19,4.94,19h0c0.68,0,1.32-0.27,1.8-0.75L9,16h6l2.25,2.25c0.48,0.48,1.13,0.75,1.8,0.75h0 C20.61,19,21.8,17.63,21.58,16.09z M11,11H9v2H8v-2H6v-1h2V8h1v2h2V11z M15,10c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1 C16,9.55,15.55,10,15,10z M17,13c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C18,12.55,17.55,13,17,13z"/>
-              </svg>
-            </LogoIcon>
-            <h1>EZGG</h1>
-          </Logo>
-          </a>
-          <UserSection>
-            {isLoggedIn ? (
-              <>
-                <UserInfo>
-                  {userInfo.riotUsername} #{userInfo.riotTag}
-                </UserInfo>
-                <LogoutButton 
-                  onClick={handleLogout} 
-                  disabled={isLoggingOut}
-                  style={{ opacity: isLoggingOut ? 0.7 : 1 }}
-                >
-                  {isLoggingOut ? '로그아웃 중...' : '로그아웃'}
-                </LogoutButton>
-              </>
-            ) : (
-              <LoginButton to="/login">
-                Login
-              </LoginButton>
-            )}
-          </UserSection>
-        </Header>
-        <Routes>
-          <Route path="/" element={
-            <ProtectedRoute 
-              element={
-              <>
-                <DuoFinder
-                  memberDataBundle={memberDataBundle}
-                  isLoading={userDataLoading}
-                  userInfo={userInfo}
-                  matchingCriteria={matchingCriteria}
-                  isMatching={isMatching}
-                  setMatchingCriteria={setMatchingCriteria}
-                  matchResult={matchResult}
-                />
-                <MatchingButtonPanel
-                  matchingCriteria={matchingCriteria}
-                  matchResult={matchResult}
-                  isMatching={isMatching}
-                  onStart={() => handleMatchStart(matchingCriteria)}
-                  onCancel={handleMatchCancel}
-                />
-              </>
-              } 
-              isLoggedIn={isLoggedIn} 
-            />
-          } />
-          <Route path="/login" element={<Login setIsLoggedIn={setIsLoggedIn} onLoginSuccess={fetchUserInfo} />} />
-          <Route path="/join" element={<Join />} />
-        </Routes>
-      </AppContainer>
-    </Router>
-  );
+    // WebSocket 관련 핸들러 정의
+    const handleSocketMessage = (message) => {
+        console.log('[App] 웹소켓 메시지 수신:', message);
+        // 필요한 경우 메시지 처리 로직 추가
+    };
+
+    const handleSocketConnect = () => {
+        console.log('[App] 웹소켓 연결 성공');
+    };
+
+    const handleSocketDisconnect = () => {
+        console.log('[App] 웹소켓 연결 해제');
+    };
+
+    const handleSocketError = (error) => {
+        console.error('[App] 웹소켓 에러:', error);
+    };
+
+    // useWebSocket 훅 사용
+    const {connect, disconnect} = useWebSocket({
+        onMessage: handleSocketMessage,
+        onConnect: handleSocketConnect,
+        onDisconnect: handleSocketDisconnect,
+        onError: handleSocketError
+    });
+
+    const {
+        matchResult,
+        setMatchResult,
+        matchingCriteria,
+        setMatchingCriteria,
+        isMatching,
+        handleMatchStart,
+        handleMatchCancel
+    } = useMatchingSystem();
+
+    // 앱 시작 시 로컬 스토리지에서 토큰을 확인하여 로그인 상태 유지
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        if (token) {
+            console.log('토큰 발견, 자동 로그인 시도');
+            // 토큰이 있으면 우선 로그인 상태로 설정하고 사용자 정보 요청
+            setIsLoggedIn(true);
+            fetchUserInfo();
+        } else {
+            setUserDataLoading(false);
+        }
+    }, []);
+
+    // 토큰을 사용하여 사용자 정보 가져오기
+    const fetchUserInfo = async () => {
+        setUserDataLoading(true);
+        try {
+            console.log('사용자 정보 요청 중...');
+            // 첫 번째 API 요청: 기본 사용자 정보
+            const memberInfoResponse = await api.get('/auth/memberinfo');
+            console.log('사용자 정보 API 응답:', memberInfoResponse);
+
+            // 기본 사용자 정보 설정
+            if (memberInfoResponse.data && memberInfoResponse.data.data) {
+                console.log('기본 사용자 정보 가져오기 성공:', memberInfoResponse.data.data);
+                setUserInfo({
+                    riotUsername: memberInfoResponse.data.data.riotUsername || '사용자',
+                    riotTag: memberInfoResponse.data.data.riotTag || 'KR'
+                });
+
+                connect();
+                console.log('[App] 웹소켓 연결 시작');
+
+                try {
+                    // 두 번째 API 요청: 추가 사용자 데이터 번들 (첫 번째 요청 성공 시에만)
+                    const dataBundleResponse = await api.get('/auth/memberdatabundle');
+                    console.log('데이터 번들 API 응답:', dataBundleResponse);
+
+                    // 추가 데이터가 있으면 저장
+                    if (dataBundleResponse.data && dataBundleResponse.data.data) {
+                        console.log('사용자 데이터 번들 가져오기 성공:', dataBundleResponse.data.data);
+                        setMemberDataBundle(dataBundleResponse.data.data);
+                    }
+                } catch (bundleError) {
+                    // 데이터 번들 요청 실패 - 로그만 남기고 기본 사용자 정보는 유지
+                    console.error('사용자 데이터 번들 가져오기 실패:', bundleError);
+                    // 401/403 오류가 아닌 경우 무시하고 계속 진행
+                    if (!(bundleError.response &&
+                        (bundleError.response.status === 401 || bundleError.response.status === 403))) {
+                        // 401/403이 아닌 다른 오류는 무시
+                    }
+                }
+            }
+        } catch (error) {
+            console.error('사용자 정보 가져오기 실패:', error);
+        } finally {
+            setUserDataLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (userInfo) {
+            console.log('userInfo 변경됨:', userInfo);
+        }
+    }, [userInfo]);
+
+    // 로그아웃 함수
+    const handleLogout = async () => {
+        console.log('로그아웃 처리 시작');
+        setIsLoggingOut(true);
+
+        try {
+            // 토큰 가져오기
+            const token = localStorage.getItem('token');
+
+            if (!token) {
+                console.warn('토큰이 없습니다. 로컬에서만 로그아웃합니다.');
+            } else {
+                // 백엔드 로그아웃 API 호출 (인터셉터가 자동으로 토큰을 헤더에 추가)
+                const response = await api.post('/auth/logout');
+                console.log('서버 로그아웃 응답 상태:', response.status);
+                console.log('서버 로그아웃 성공:', response.data);
+            }
+        } catch (error) {
+            console.error('서버 로그아웃 실패:', error);
+            if (error.response) {
+                console.error('응답 상태:', error.response.status);
+                console.error('응답 데이터:', error.response.data);
+            }
+            // 서버 로그아웃에 실패하더라도 클라이언트 측 로그아웃은 진행
+        } finally {
+            // 웹소켓 연결 해제
+            disconnect();
+            console.log('[App] 로그아웃 시 웹소켓 연결 해제됨');
+
+            // 로컬 스토리지에서 토큰 제거
+            localStorage.removeItem('token');
+
+            // 상태 초기화
+            setIsLoggedIn(false);
+            setUserInfo({
+                riotUsername: '',
+                riotTag: ''
+            });
+            setMemberDataBundle(null);
+
+            console.log('로그아웃 처리 완료');
+            setIsLoggingOut(false);
+        }
+    };
+
+    return (
+        <Router>
+            <AppContainer>
+                <Header>
+                    <a href="/">
+                        <Logo>
+                            <LogoIcon>
+                                <svg viewBox="0 0 24 24">
+                                    <path
+                                        d="M21.58,16.09l-1.09-7.66C20.21,6.46,18.52,5,16.53,5H7.47C5.48,5,3.79,6.46,3.51,8.43l-1.09,7.66 C2.2,17.63,3.39,19,4.94,19h0c0.68,0,1.32-0.27,1.8-0.75L9,16h6l2.25,2.25c0.48,0.48,1.13,0.75,1.8,0.75h0 C20.61,19,21.8,17.63,21.58,16.09z M11,11H9v2H8v-2H6v-1h2V8h1v2h2V11z M15,10c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1 C16,9.55,15.55,10,15,10z M17,13c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C18,12.55,17.55,13,17,13z"/>
+                                </svg>
+                            </LogoIcon>
+                            <h1>EZGG</h1>
+                        </Logo>
+                    </a>
+                    <UserSection>
+                        {isLoggedIn ? (
+                            <>
+                                <UserInfo>
+                                    {userInfo.riotUsername} #{userInfo.riotTag}
+                                </UserInfo>
+                                <LogoutButton
+                                    onClick={handleLogout}
+                                    disabled={isLoggingOut}
+                                    style={{opacity: isLoggingOut ? 0.7 : 1}}
+                                >
+                                    {isLoggingOut ? '로그아웃 중...' : '로그아웃'}
+                                </LogoutButton>
+                            </>
+                        ) : (
+                            <LoginButton to="/login">
+                                Login
+                            </LoginButton>
+                        )}
+                    </UserSection>
+                </Header>
+                <Routes>
+                    <Route path="/" element={
+                        <ProtectedRoute
+                            element={
+                                <>
+                                    <DuoFinder
+                                        memberDataBundle={memberDataBundle}
+                                        isLoading={userDataLoading}
+                                        userInfo={userInfo}
+                                        matchingCriteria={matchingCriteria}
+                                        isMatching={isMatching}
+                                        setMatchingCriteria={setMatchingCriteria}
+                                        matchResult={matchResult}
+                                    />
+                                    <MatchingButtonPanel
+                                        matchingCriteria={matchingCriteria}
+                                        matchResult={matchResult}
+                                        isMatching={isMatching}
+                                        onStart={() => handleMatchStart(matchingCriteria)}
+                                        onCancel={handleMatchCancel}
+                                    />
+                                </>
+                            }
+                            isLoggedIn={isLoggedIn}
+                        />
+                    }/>
+                    <Route path="/login"
+                           element={<Login setIsLoggedIn={setIsLoggedIn} onLoginSuccess={fetchUserInfo}/>}/>
+                    <Route path="/join" element={<Join/>}/>
+                </Routes>
+            </AppContainer>
+        </Router>
+    );
 };
 
 export default App;
 
 const AppContainer = styled.div`
-  min-height: 100vh;
-  background: #0F0F0F;
+    min-height: 100vh;
+    background: #0F0F0F;
 `;
 
 const Header = styled.header`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2rem;
-  background: rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(10px);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+    background: rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(10px);
 `;
 
 const Logo = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  
-  h1 {
-    color: white;
-    font-size: 1.5rem;
-    font-weight: 800;
-  }
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    h1 {
+        color: white;
+        font-size: 1.5rem;
+        font-weight: 800;
+    }
 `;
 
 const LogoIcon = styled.div`
-  width: 28px;
-  height: 28px;
-  background: white;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  
-  svg {
-    width: 18px;
-    height: 18px;
-    fill: black;
-  }
+    width: 28px;
+    height: 28px;
+    background: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    svg {
+        width: 18px;
+        height: 18px;
+        fill: black;
+    }
 `;
 
 const UserSection = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
 `;
 
 const UserInfo = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: white;
-  cursor: pointer;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  background: rgba(255, 255, 255, 0.1);
-  transition: background 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: white;
+    cursor: pointer;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.1);
+    transition: background 0.2s;
 
-  &:hover {
-    background: rgba(255, 255, 255, 0.2);
-  }
+    &:hover {
+        background: rgba(255, 255, 255, 0.2);
+    }
 `;
 
 const LoginButton = styled(Link)`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: white;
-  cursor: pointer;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  background: #FF416C;
-  text-decoration: none;
-  transition: opacity 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: white;
+    cursor: pointer;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    background: #FF416C;
+    text-decoration: none;
+    transition: opacity 0.2s;
 
-  &:hover {
-    opacity: 0.9;
-  }
+    &:hover {
+        opacity: 0.9;
+    }
 `;
 
 const LogoutButton = styled.button`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: white;
-  cursor: pointer;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  background: #FF416C;
-  text-decoration: none;
-  transition: opacity 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: white;
+    cursor: pointer;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    background: #FF416C;
+    text-decoration: none;
+    transition: opacity 0.2s;
 
-  &:hover {
-    opacity: 0.9;
-  }
+    &:hover {
+        opacity: 0.9;
+    }
 `;

--- a/frontend/ezgg/src/components/Chatting/ChatRoom.jsx
+++ b/frontend/ezgg/src/components/Chatting/ChatRoom.jsx
@@ -1,0 +1,269 @@
+import React, {useEffect, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+
+const ChatRoom = ({userInfo, matchResult, chatMessages, sendChatMessage, isConnected}) => {
+    const [messages, setMessages] = useState([
+        {id: 1, sender: 'System', text: '채팅방에 오신 것을 환영합니다!', timestamp: new Date().toISOString()}
+    ]);
+    const [input, setInput] = useState('');
+    const messagesEndRef = useRef(null);
+
+    // App.jsx에서 전달받은 채팅 메시지를 messages에 추가 - 단순화
+    useEffect(() => {
+        console.log('[ChatRoom] chatMessages 업데이트:', chatMessages);
+
+        if (chatMessages && chatMessages.length > 0) {
+            // 가장 최근 메시지만 처리
+            const latestMessage = chatMessages[chatMessages.length - 1];
+            console.log('[ChatRoom] 최신 메시지:', latestMessage);
+
+            // 서버에서 오는 메시지 구조에 맞춰 변환
+            const formattedMessage = {
+                id: Date.now() + Math.random(),
+                sender: latestMessage.sender || '알 수 없음',
+                text: latestMessage.message || latestMessage.text || '',
+                timestamp: latestMessage.timestamp || new Date().toISOString(),
+                isOwn: latestMessage.sender === userInfo.riotUsername // 내가 보낸 메시지인지 확인
+            };
+
+            // 중복 체크 단순화 - 최근 5개 메시지와만 비교
+            const recentMessages = messages.slice(-5);
+            const isDuplicate = recentMessages.some(msg =>
+                msg.sender === formattedMessage.sender &&
+                msg.text === formattedMessage.text &&
+                Math.abs(new Date(msg.timestamp) - new Date(formattedMessage.timestamp)) < 2000
+            );
+
+            if (!isDuplicate) {
+                console.log('[ChatRoom] 새 메시지 추가:', formattedMessage);
+                setMessages(prev => [...prev, formattedMessage]);
+            } else {
+                console.log('[ChatRoom] 중복 메시지 무시');
+            }
+        }
+    }, [chatMessages, userInfo.riotUsername]);
+
+    // 새 메시지 스크롤 아래로 자동 이동
+    useEffect(() => {
+        messagesEndRef.current?.scrollIntoView({behavior: 'smooth'});
+    }, [messages]);
+
+    // 메시지 보내기 함수
+    const sendMessage = () => {
+        if (!input.trim()) return;
+        if (!matchResult?.chattingRoomId) {
+            alert('채팅방 정보가 없습니다.');
+            return;
+        }
+
+        console.log('[ChatRoom] 메시지 전송:', {
+            chattingRoomId: matchResult.chattingRoomId,
+            message: input.trim(),
+            sender: userInfo.riotUsername
+        });
+
+        // 내가 보낸 메시지를 즉시 화면에 표시 (UI 반응성을 위해)
+        const newMsg = {
+            id: Date.now(),
+            sender: userInfo.riotUsername || '나',
+            text: input.trim(),
+            timestamp: new Date().toISOString(),
+            isOwn: true
+        };
+
+        setMessages(prev => [...prev, newMsg]);
+
+        // WebSocket으로 메시지 전송
+        sendChatMessage(
+            matchResult.chattingRoomId,
+            input.trim(),
+            userInfo.riotUsername || '익명'
+        );
+
+        setInput('');
+    };
+
+    // Enter키로 메시지 보내기
+    const handleKeyDown = (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            sendMessage();
+        }
+    };
+
+    console.log('[ChatRoom] 렌더링 - 메시지 수:', messages.length, '연결 상태:', isConnected);
+
+    return (
+        <ChatContainer>
+            <ChatHeader>
+                💬 채팅방 - {matchResult?.opponentInfo?.riotUsername || '상대방'}#{matchResult?.opponentInfo?.riotTag || 'KR'}
+                {isConnected ?
+                    <ConnectionStatus connected>● 연결됨</ConnectionStatus> :
+                    <ConnectionStatus>● 연결 끊김</ConnectionStatus>
+                }
+            </ChatHeader>
+            <Messages>
+                {messages.map(msg => (
+                    <Message key={msg.id} isOwn={msg.isOwn || msg.sender === userInfo.riotUsername}>
+                        <MessageContent isOwn={msg.isOwn || msg.sender === userInfo.riotUsername}>
+                            <Sender isOwn={msg.isOwn || msg.sender === userInfo.riotUsername}>
+                                {msg.sender}:
+                            </Sender>
+                            <MessageText>{msg.text}</MessageText>
+                            <MessageTime>
+                                {new Date(msg.timestamp).toLocaleTimeString('ko-KR', {
+                                    hour: '2-digit',
+                                    minute: '2-digit'
+                                })}
+                            </MessageTime>
+                        </MessageContent>
+                    </Message>
+                ))}
+                <div ref={messagesEndRef}/>
+            </Messages>
+            <InputWrapper>
+                <ChatInput
+                    type="text"
+                    placeholder={`메시지 입력... (연결: ${isConnected ? 'ON' : 'OFF'})`}
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                />
+                <SendButton onClick={sendMessage} disabled={!input.trim() || !isConnected}>
+                    전송
+                </SendButton>
+            </InputWrapper>
+        </ChatContainer>
+    );
+};
+
+export default ChatRoom;
+
+// 스타일 컴포넌트
+const ChatContainer = styled.div`
+    width: 100%;
+    max-width: 600px;
+    height: 400px;
+    margin: 1rem auto;
+    background: #1e1e1e;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+`;
+
+const ChatHeader = styled.div`
+    padding: 0.75rem 1rem;
+    background: #222;
+    color: white;
+    font-weight: bold;
+    border-radius: 8px 8px 0 0;
+    border-bottom: 1px solid #333;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`;
+
+const ConnectionStatus = styled.span`
+    font-size: 0.8rem;
+    color: ${({connected}) => (connected ? '#4caf50' : '#f44336')};
+    font-weight: normal;
+`;
+
+const Messages = styled.div`
+    flex-grow: 1;
+    padding: 1rem;
+    overflow-y: auto;
+    color: white;
+    font-size: 0.9rem;
+
+    &::-webkit-scrollbar {
+        width: 6px;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: #2a2a2a;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: #555;
+        border-radius: 3px;
+    }
+`;
+
+const Message = styled.div`
+    margin-bottom: 0.5rem;
+    display: flex;
+    justify-content: ${({isOwn}) => (isOwn ? 'flex-end' : 'flex-start')};
+`;
+
+const MessageContent = styled.div`
+    max-width: 70%;
+    padding: 0.5rem 0.75rem;
+    border-radius: 12px;
+    background: ${({isOwn}) => (isOwn ? '#4caf50' : '#333')};
+    word-wrap: break-word;
+`;
+
+const Sender = styled.div`
+    font-weight: 600;
+    font-size: 0.8rem;
+    margin-bottom: 0.2rem;
+    color: ${({isOwn}) => (isOwn ? '#e8f5e8' : '#bbb')};
+`;
+
+const MessageText = styled.div`
+    color: white;
+    line-height: 1.4;
+    margin-bottom: 0.2rem;
+`;
+
+const MessageTime = styled.div`
+    font-size: 0.7rem;
+    color: ${({isOwn}) => (isOwn ? '#c8e6c9' : '#999')};
+    text-align: right;
+`;
+
+const InputWrapper = styled.div`
+    display: flex;
+    padding: 0.5rem 1rem;
+    background: #222;
+    border-radius: 0 0 8px 8px;
+    border-top: 1px solid #333;
+`;
+
+const ChatInput = styled.input`
+    flex-grow: 1;
+    padding: 0.5rem 0.75rem;
+    background: #333;
+    border: none;
+    border-radius: 4px;
+    color: white;
+    font-size: 1rem;
+    font-family: inherit;
+
+    &:focus {
+        outline: none;
+        background: #444;
+    }
+
+    &::placeholder {
+        color: #888;
+    }
+`;
+
+const SendButton = styled.button`
+    margin-left: 0.75rem;
+    background: ${({disabled}) => (disabled ? '#666' : '#FF416C')};
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 0 1rem;
+    cursor: ${({disabled}) => (disabled ? 'not-allowed' : 'pointer')};
+    transition: all 0.2s;
+
+    &:hover {
+        opacity: ${({disabled}) => (disabled ? '1' : '0.9')};
+        transform: ${({disabled}) => (disabled ? 'none' : 'translateY(-1px)')};
+    }
+`;

--- a/frontend/ezgg/src/components/DuoFinder/DuoFinder.jsx
+++ b/frontend/ezgg/src/components/DuoFinder/DuoFinder.jsx
@@ -18,13 +18,6 @@ const DuoFinder = (
         isConnected
     }
 ) => {
-    console.log('[DuoFinder] Props:', {
-        matchResult,
-        chatMessages,
-        isConnected,
-        userInfo
-    });
-
     return (
         <Container>
             <UserProfileCard

--- a/frontend/ezgg/src/components/DuoFinder/DuoFinder.jsx
+++ b/frontend/ezgg/src/components/DuoFinder/DuoFinder.jsx
@@ -2,39 +2,64 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {UserProfileCard} from "./user/UserProfileCard.jsx";
 import {MatchingInterface} from "./matching/MatchingInterface.jsx";
+import ChatRoom from "../Chatting/ChatRoom.jsx";
 
 const DuoFinder = (
-  {
-    memberDataBundle,
-    isLoading,
-    userInfo,
-    matchingCriteria,
-    isMatching,
-    setMatchingCriteria,
-    matchResult
-  }
+    {
+        memberDataBundle,
+        isLoading,
+        userInfo,
+        matchingCriteria,
+        isMatching,
+        setMatchingCriteria,
+        matchResult,
+        chatMessages,
+        sendChatMessage,
+        isConnected
+    }
 ) => {
+    console.log('[DuoFinder] Props:', {
+        matchResult,
+        chatMessages,
+        isConnected,
+        userInfo
+    });
+
     return (
-      <Container>
-        <UserProfileCard
-          userInfo={userInfo}
-          memberDataBundle={memberDataBundle}
-          isLoading={isLoading}
-        />
-        {matchResult ? (
-          <UserProfileCard
-            memberDataBundle={matchResult.data}
-            isLoading={isLoading}
-          />
-        ) : (
-          <MatchingInterface
-            matchResult={matchResult}
-            matchingCriteria={matchingCriteria}
-            isMatching={isMatching}
-            setMatchingCriteria={setMatchingCriteria}
-          />
-        )}
-      </Container>
+        <Container>
+            <UserProfileCard
+                userInfo={userInfo}
+                memberDataBundle={memberDataBundle}
+                isLoading={isLoading}
+            />
+
+            {matchResult ? (
+                <MatchedContainer>
+                    {/* 상대방 카드 */}
+                    <UserProfileCard
+                        memberDataBundle={matchResult.data}
+                        isLoading={isLoading}
+                        isOpponent={true}
+                    />
+
+                    {/* 채팅방 */}
+                    <ChatRoom
+                        userInfo={userInfo}
+                        matchResult={matchResult}
+                        chatMessages={chatMessages}
+                        sendChatMessage={sendChatMessage}
+                        isConnected={isConnected}
+                    />
+                </MatchedContainer>
+            ) : (
+                <MatchingInterface
+                    matchResult={matchResult}
+                    matchingCriteria={matchingCriteria}
+                    isMatching={isMatching}
+                    setMatchingCriteria={setMatchingCriteria}
+                />
+            )}
+        </Container>
     )
 };
 
@@ -47,7 +72,7 @@ const Container = styled.div`
     width: 100%;
     max-width: 1400px;
     margin: 0 auto;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
 
     @media (max-width: 1024px) {
@@ -55,4 +80,11 @@ const Container = styled.div`
         flex-direction: column;
         align-items: center;
     }
+`;
+
+const MatchedContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    align-items: center;
 `;

--- a/frontend/ezgg/src/components/auth/Login.jsx
+++ b/frontend/ezgg/src/components/auth/Login.jsx
@@ -1,8 +1,179 @@
-import React, {useState, useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import {Link, useNavigate, useLocation} from 'react-router-dom';
-import api from '../../utils/api';
+import {Link, useLocation, useNavigate} from 'react-router-dom';
 import axios from 'axios';
+
+const Login = ({setIsLoggedIn, onLoginSuccess}) => {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const [formData, setFormData] = useState({
+        username: '',
+        password: '',
+    });
+
+    const [errors, setErrors] = useState({
+        username: '',
+        password: '',
+    });
+
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        if (token) {
+            console.log('이미 로그인 되어 있음, 홈으로 리다이렉트');
+            navigate('/');
+        }
+    }, [navigate]);
+
+    const validateForm = () => {
+        let isValid = true;
+        const newErrors = {
+            username: '',
+            password: '',
+        };
+
+        if (!formData.username) {
+            newErrors.username = '아이디를 입력해주세요';
+            isValid = false;
+        }
+
+        if (!formData.password) {
+            newErrors.password = '비밀번호를 입력해주세요';
+            isValid = false;
+        }
+
+        setErrors(newErrors);
+        return isValid;
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        if (!validateForm()) {
+            return;
+        }
+        console.log('로그인 시도:', formData);
+
+        try {
+            const response = await axios.post('http://localhost:8888/login', {
+                memberUsername: formData.username,
+                password: formData.password
+            }, {
+                withCredentials: true
+            });
+
+            console.log('로그인 응답 전체:', response);
+            console.log('응답 헤더:', response.headers);
+
+            // 토큰 확인 (Authorization 헤더에서 획득)
+            let token = response.headers['authorization'];
+            console.log('token : ', token)
+
+            // 토큰이 없는 경우 response.headers에서 대소문자 구분 없이 찾기
+            if (!token) {
+                const headerNames = Object.keys(response.headers);
+                console.log('사용 가능한 헤더:', headerNames);
+
+                for (const header of headerNames) {
+                    if (header.toLowerCase() === 'authorization') {
+                        token = response.headers[header];
+                        console.log('찾은 토큰 헤더:', header, token);
+                        break;
+                    }
+                }
+            }
+
+            if (response.status === 200 && token) {
+                console.log('로그인 성공, 토큰 저장:', token);
+
+                // Bearer 접두사가 없으면 추가
+                if (!token.startsWith('Bearer ')) {
+                    token = `Bearer ${token}`;
+                }
+
+                localStorage.setItem('token', token);
+                console.log('로컬 스토리지에 저장된 토큰:', localStorage.getItem('token'));
+
+                // 로그인 상태 업데이트
+                setIsLoggedIn(true);
+
+                // 사용자 정보 가져오기
+                if (onLoginSuccess) {
+                    console.log('사용자 정보 가져오기 함수 호출');
+                    onLoginSuccess();
+                }
+
+                // 로그인 성공 후, 원래 가려던 페이지로 리다이렉트 (없으면 홈으로)
+                const from = location.state?.from?.pathname || '/';
+                console.log('리다이렉트 경로:', from);
+                navigate(from, {replace: true});
+            } else {
+                console.error('로그인 실패: 토큰 없음', response);
+                // 응답은 성공이지만 토큰이 없는 경우 확인
+                if (response.data && response.data.message) {
+                    alert(`로그인에 실패했습니다: ${response.data.message}`);
+                } else {
+                    alert('로그인에 실패했습니다. 서버 응답에 토큰이 없습니다.');
+                }
+            }
+        } catch (error) {
+            console.error('로그인 오류 상세 정보:', error.response || error);
+
+            // 서버에서 오는 오류 메시지 있으면 표시
+            if (error.response && error.response.data && error.response.data.message) {
+                alert(`로그인 오류: ${error.response.data.message}`);
+            } else {
+                alert('로그인에 실패했습니다. 아이디와 비밀번호를 확인해주세요.');
+            }
+        }
+    };
+
+    const handleChange = (e) => {
+        const {name, value} = e.target;
+        setFormData(prev => ({
+            ...prev,
+            [name]: value
+        }));
+        setErrors(prev => ({
+            ...prev,
+            [name]: ''
+        }));
+    };
+
+    return (
+        <Container>
+            <FormContainer>
+                <Title>로그인</Title>
+                <Form onSubmit={handleSubmit}>
+                    <InputGroup>
+                        <Label>아이디</Label>
+                        <Input
+                            type="text"
+                            name="username"
+                            placeholder="아이디를 입력하세요"
+                            value={formData.username}
+                            onChange={handleChange}
+                        />
+                        {errors.username && <ErrorMessage>{errors.username}</ErrorMessage>}
+                    </InputGroup>
+                    <InputGroup>
+                        <Label>비밀번호</Label>
+                        <Input
+                            type="password"
+                            name="password"
+                            placeholder="비밀번호를 입력하세요"
+                            value={formData.password}
+                            onChange={handleChange}
+                        />
+                        {errors.password && <ErrorMessage>{errors.password}</ErrorMessage>}
+                    </InputGroup>
+                    <SubmitButton type="submit">로그인</SubmitButton>
+                </Form>
+                <JoinLink to="/join">회원가입하기</JoinLink>
+            </FormContainer>
+        </Container>
+    );
+};
+
+export default Login;
 
 const Container = styled.div`
     display: flex;
@@ -102,175 +273,3 @@ const JoinLink = styled(Link)`
         text-decoration: underline;
     }
 `;
-
-const Login = ({setIsLoggedIn, onLoginSuccess}) => {
-    const navigate = useNavigate();
-    const location = useLocation();
-    const [formData, setFormData] = useState({
-        username: '',
-        password: '',
-    });
-
-    const [errors, setErrors] = useState({
-        username: '',
-        password: '',
-    });
-
-    useEffect(() => {
-        const token = localStorage.getItem('token');
-        if (token) {
-            console.log('이미 로그인 되어 있음, 홈으로 리다이렉트');
-            navigate('/');
-        }
-    }, [navigate]);
-
-    const validateForm = () => {
-        let isValid = true;
-        const newErrors = {
-            username: '',
-            password: '',
-        };
-
-        if (!formData.username) {
-            newErrors.username = '아이디를 입력해주세요';
-            isValid = false;
-        }
-
-        if (!formData.password) {
-            newErrors.password = '비밀번호를 입력해주세요';
-            isValid = false;
-        }
-
-        setErrors(newErrors);
-        return isValid;
-    };
-
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        if (!validateForm()) {
-            return;
-        }
-        console.log('로그인 시도:', formData);
-
-        try {
-            const response = await axios.post('http://localhost:8888/login', {
-                memberUsername: formData.username,
-                password: formData.password
-            }, {
-                withCredentials: true
-            });
-
-            console.log('로그인 응답 전체:', response);
-            console.log('응답 헤더:', response.headers);
-
-            // 토큰 확인 (Authorization 헤더에서 획득)
-            let token = response.headers['authorization'];
-            console.log('token : ', token)
-            
-            // 토큰이 없는 경우 response.headers에서 대소문자 구분 없이 찾기
-            if (!token) {
-                const headerNames = Object.keys(response.headers);
-                console.log('사용 가능한 헤더:', headerNames);
-                
-                for (const header of headerNames) {
-                    if (header.toLowerCase() === 'authorization') {
-                        token = response.headers[header];
-                        console.log('찾은 토큰 헤더:', header, token);
-                        break;
-                    }
-                }
-            }
-
-            if (response.status === 200 && token) {
-                console.log('로그인 성공, 토큰 저장:', token);
-                
-                // Bearer 접두사가 없으면 추가
-                if (!token.startsWith('Bearer ')) {
-                    token = `Bearer ${token}`;
-                }
-                
-                localStorage.setItem('token', token);
-                console.log('로컬 스토리지에 저장된 토큰:', localStorage.getItem('token'));
-                
-                // 로그인 상태 업데이트
-                setIsLoggedIn(true);
-                
-                // 사용자 정보 가져오기
-                if (onLoginSuccess) {
-                    console.log('사용자 정보 가져오기 함수 호출');
-                    onLoginSuccess();
-                }
-                
-                // 로그인 성공 후, 원래 가려던 페이지로 리다이렉트 (없으면 홈으로)
-                const from = location.state?.from?.pathname || '/';
-                console.log('리다이렉트 경로:', from);
-                navigate(from, { replace: true });
-            } else {
-                console.error('로그인 실패: 토큰 없음', response);
-                // 응답은 성공이지만 토큰이 없는 경우 확인
-                if (response.data && response.data.message) {
-                    alert(`로그인에 실패했습니다: ${response.data.message}`);
-                } else {
-                    alert('로그인에 실패했습니다. 서버 응답에 토큰이 없습니다.');
-                }
-            }
-        } catch (error) {
-            console.error('로그인 오류 상세 정보:', error.response || error);
-            
-            // 서버에서 오는 오류 메시지 있으면 표시
-            if (error.response && error.response.data && error.response.data.message) {
-                alert(`로그인 오류: ${error.response.data.message}`);
-            } else {
-                alert('로그인에 실패했습니다. 아이디와 비밀번호를 확인해주세요.');
-            }
-        }
-    };
-
-    const handleChange = (e) => {
-        const {name, value} = e.target;
-        setFormData(prev => ({
-            ...prev,
-            [name]: value
-        }));
-        setErrors(prev => ({
-            ...prev,
-            [name]: ''
-        }));
-    };
-
-    return (
-        <Container>
-            <FormContainer>
-                <Title>로그인</Title>
-                <Form onSubmit={handleSubmit}>
-                    <InputGroup>
-                        <Label>아이디</Label>
-                        <Input
-                            type="text"
-                            name="username"
-                            placeholder="아이디를 입력하세요"
-                            value={formData.username}
-                            onChange={handleChange}
-                        />
-                        {errors.username && <ErrorMessage>{errors.username}</ErrorMessage>}
-                    </InputGroup>
-                    <InputGroup>
-                        <Label>비밀번호</Label>
-                        <Input
-                            type="password"
-                            name="password"
-                            placeholder="비밀번호를 입력하세요"
-                            value={formData.password}
-                            onChange={handleChange}
-                        />
-                        {errors.password && <ErrorMessage>{errors.password}</ErrorMessage>}
-                    </InputGroup>
-                    <SubmitButton type="submit">로그인</SubmitButton>
-                </Form>
-                <JoinLink to="/join">회원가입하기</JoinLink>
-            </FormContainer>
-        </Container>
-    );
-};
-
-export default Login; 

--- a/frontend/ezgg/src/hooks/useMatchingSystem.js
+++ b/frontend/ezgg/src/hooks/useMatchingSystem.js
@@ -8,11 +8,10 @@ export const useMatchingSystem = () => {
     const [matchingCriteria, setMatchingCriteria] = useState(getInitialCriteria());
     const [isMatching, setIsMatching] = useState(false);
 
-    const {connect, disconnect, sendMatchingRequest, sendCancelRequest} = useWebSocket({
+    const {connect, sendMatchingRequest, sendCancelRequest} = useWebSocket({
         onMessage: (response) => {
             alert('매칭 성공! 상대방 정보를 확인해주세요.');
-            setMatchResult(response)
-            disconnect();
+            setMatchResult(response);
         }, onConnect: () => {
             console.log('매칭 시스템 웹소켓 연결 완료');
         }, onDisconnect: () => {
@@ -60,12 +59,6 @@ export const useMatchingSystem = () => {
         });
     };
 
-    // const handleDisconnect = () => {
-    //     disconnect();
-    //     setIsMatching(false);
-    //     setMatchingCriteria(getInitialCriteria());
-    // } -> 이거는 필요없을듯 useWebSocket에서 연결 해제하는 함수가 이미 있음
-
     const handleMatchCancel = () => {
         if (isMatching) {
             // 매칭 중일 때만 취소 요청을 백엔드로 전송
@@ -76,7 +69,6 @@ export const useMatchingSystem = () => {
         setIsMatching(false);
         setMatchingCriteria(getInitialCriteria());
         // 웹소켓 연결 종료
-        disconnect();
     };
 
     useEffect(() => {
@@ -87,7 +79,6 @@ export const useMatchingSystem = () => {
                 // 매칭 중에 컴포넌트가 언마운트되면 취소 요청 전송
                 sendCancelRequest();
             }
-            disconnect();
         };
     }, [isMatching]);
 

--- a/frontend/ezgg/src/hooks/useMatchingSystem.js
+++ b/frontend/ezgg/src/hooks/useMatchingSystem.js
@@ -1,50 +1,11 @@
 import {useEffect, useState} from 'react';
 import {isValidCriteria} from '../utils/validation.js';
-import {useWebSocket} from "./useWebSocket.js";
 import {getInitialCriteria} from "../utils/initialStates.js";
 
-export const useMatchingSystem = () => {
+export const useMatchingSystem = ({socket, sendMatchingRequest, sendCancelRequest, onMatchMessage}) => {
     const [matchResult, setMatchResult] = useState(null);
     const [matchingCriteria, setMatchingCriteria] = useState(getInitialCriteria());
     const [isMatching, setIsMatching] = useState(false);
-
-    const {connect, sendMatchingRequest, sendCancelRequest} = useWebSocket({
-        onMessage: (response) => {
-            alert('매칭 성공! 상대방 정보를 확인해주세요.');
-            setMatchResult(response);
-        }, onConnect: () => {
-            console.log('매칭 시스템 웹소켓 연결 완료');
-        }, onDisconnect: () => {
-            console.log('매칭 시스템 웹소켓 연결 종료');
-            setMatchingCriteria(getInitialCriteria());
-            setIsMatching(false);
-        }, onError: (message) => {
-            alert('에러 발생: ' + message);
-            setIsMatching(false);
-        }
-        // onMessage: (response) => {
-        //   console.log(response)
-        //   if (response.status === 'SUCCESS') {
-        //     setMatchResult(response.data);
-        //     alert('매칭 성공! 상대방 정보를 확인하세요.')
-        //     disconnect()
-        //     setIsMatching(false);
-        //   } else {
-        //     console.error('매칭 실패:', response.message);
-        //     alert('매칭에 실패하였습니다. 조건을 다시 설정해주세요.')
-        //     disconnect();
-        //   }
-        //   setIsMatching(false);
-        // },
-        // onDisconnect: () => {
-        //   console.log('연결 종료');
-        //   setIsMatching(false);
-        // },
-        // onError: (message) => {
-        //   alert('에러 발생 : ' + message);
-        //   setIsMatching(false);
-        // }
-    });
 
     const handleMatchStart = (criteria) => {
         if (!isValidCriteria(criteria)) {
@@ -52,35 +13,43 @@ export const useMatchingSystem = () => {
             return;
         }
 
-        setIsMatching(() => true);
-        connect(() => {
-            sendMatchingRequest(criteria);
-            setMatchingCriteria(criteria);
-        });
+        if (!socket) {
+            alert('웹소켓 연결이 필요합니다.');
+            return;
+        }
+
+        console.log('[useMatchingSystem] 매칭 시작:', criteria);
+        setIsMatching(true);
+        setMatchingCriteria(criteria);
+
+        // App.jsx에서 전달받은 sendMatchingRequest 사용
+        sendMatchingRequest(criteria);
     };
 
     const handleMatchCancel = () => {
+        console.log('[useMatchingSystem] 매칭 취소');
+
         if (isMatching) {
             // 매칭 중일 때만 취소 요청을 백엔드로 전송
             sendCancelRequest();
         }
+
         // 상태 초기화
         setMatchResult(null);
         setIsMatching(false);
         setMatchingCriteria(getInitialCriteria());
-        // 웹소켓 연결 종료
     };
 
     useEffect(() => {
         // 컴포넌트 언마운트 시 정리
         return () => {
-            //매칭 중일때만 요청 (페이지를 떠나거나 하게되면 취소)
             if (isMatching) {
                 // 매칭 중에 컴포넌트가 언마운트되면 취소 요청 전송
+                console.log('[useMatchingSystem] 컴포넌트 언마운트, 매칭 취소');
                 sendCancelRequest();
             }
         };
-    }, [isMatching]);
+    }, [isMatching, sendCancelRequest]);
 
     return {
         matchResult,

--- a/frontend/ezgg/src/hooks/useWebSocket.js
+++ b/frontend/ezgg/src/hooks/useWebSocket.js
@@ -78,10 +78,17 @@ export const useWebSocket = ({onMessage, onConnect, onDisconnect, onError}) => {
                 console.log("[useWebSocket.js]\nWebSocket connected");
                 setIsConnected(true);
 
-
                 // 개별 유저의 매칭 결과 구독
                 stompClient.current.subscribe(`/user/queue/matching`, (message) => {
                     const response = JSON.parse(message.body);
+                    console.log('매칭 완료 메시지:', response);
+                    if (response.matched && response.chattingRoomId) {
+                        // chattingId 구독 추가
+                        stompClient.current.subscribe(`/user/queue/${response.chattingRoomId}`, (chatMsg) => {
+                            const chatResponse = JSON.parse(chatMsg.body);
+                            console.log("채팅 메시지:", chatResponse);
+                        });
+                    }
                     onMessage(response);
                 });
 


### PR DESCRIPTION
- PR 제목 양식: Feat/Fix/Refactor:#이슈번호-구현한 기능 (확인 후 지워주세요)

## 🔎 작업 내용

✨ Features:
- 로그인 시 WebSocket 자동 연결/해제
- 실시간 매칭 시스템 (조건 설정, 매칭 대기, 성공 알림)
- 양방향 실시간 채팅 (메시지 전송/수신, 브로드캐스트)
- 매칭 성공 시 상대방 정보 카드 표시
- 채팅방 UI (메시지 히스토리, 타임스탬프, 연결 상태)

🔧 Technical:
- WebSocket 중복 연결 방지 및 단일 인스턴스 관리
- STOMP 프로토콜 기반 메시지 브로커 연동
- 채팅방 참가자 관리 및 브로드캐스트 메시지 전송
- Principal ID 기반 개별 사용자 메시지 라우팅

🐛 Fixes:
- 매칭 취소 시 WebSocket 정리 로직 개선
- 채팅 메시지 중복 수신 방지
- 사용자 ID와 WebSocket Principal 매핑 문제 해결"

(기능 구현 중 웹소켓이 여러개로 생성되는 문제와 웹소켓이 제대로 끊기지 않아 다른 아이디로 접속 시 이전 아이디 기록을 사용하여 에러가 발생했음. 관련해서는 웹소켓을 연결하고 끊는 것을 app.jsx에서 컨트롤하도록 설정하여 해결함.)

## 🔧 앞으로의 과제

- 매칭 되돌아가기로 채팅방을 나가게 되었을때 상대방에게 매칭이 취소되었습니다 알림 필요
- 매칭 되돌아가기로 채팅방 나갔을때 해당 채팅방이 삭제되도록 처리

