### PR TITLE
fix/#63 로그인시 riotUsername과 tag 안 보이는 에러 수정

### DIFF
--- a/frontend/ezgg/src/components/DuoFinder/user/UserProfileCard.jsx
+++ b/frontend/ezgg/src/components/DuoFinder/user/UserProfileCard.jsx
@@ -4,8 +4,9 @@ import {WinRateStats} from "./WinRateStats.jsx";
 import {LoadingSpinner} from "../../layout/LoadingSpinner.jsx";
 import styled from '@emotion/styled';
 
-export const UserProfileCard = ({ memberDataBundle, isLoading }) => {
+export const UserProfileCard = ({ userInfo, memberDataBundle, isLoading }) => {
   const { memberInfoDto, recentTwentyMatchDto } = memberDataBundle || {};
+  const effectiveMemberInfo = memberInfoDto || userInfo;
 
   return (
     <ProfileCard>
@@ -16,7 +17,7 @@ export const UserProfileCard = ({ memberDataBundle, isLoading }) => {
           <ChampionGallery champions = {recentTwentyMatchDto?.championStats} />
           <ProfileInfo>
             <ProfileTitle>
-              {memberInfoDto?.riotUsername || "사용자"} #{memberInfoDto?.riotTag || "0000"}
+              {effectiveMemberInfo?.riotUsername || "사용자"} #{effectiveMemberInfo?.riotTag || "0000"}
             </ProfileTitle>
             <RankBadge
               tier={memberInfoDto?.tier}


### PR DESCRIPTION
## 🔎 작업 내용
- 로그인시 riotUsername과 tag 안 보이는 에러 수정
memberInfoDto가 유효하지 않은 경우 userInfo 정보를 사용하도록 수정했습니다


## 🔧 앞으로의 과제

- 할 일을

- 적어주세요

