### PR TITLE
Feat:#58-duo timeline (BE 로직)

### DIFF
--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/matchInfo/dto/MatchInfoDto.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/matchInfo/dto/MatchInfoDto.java
@@ -1,0 +1,34 @@
+package com.matching.ezgg.domain.matchInfo.dto;
+
+import com.matching.ezgg.domain.matchInfo.entity.MatchInfo;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MatchInfoDto {
+	private Long memberId;
+	private String riotMatchId;
+	private Integer kills;
+	private Integer deaths;
+	private Integer assists;
+	private String teamPosition;
+	private String championName;
+	private Boolean win;
+	private String matchAnalysis = "";
+
+	public static MatchInfoDto toMatchInfoDto(MatchInfo matchInfo) {
+		return MatchInfoDto.builder()
+			.memberId(matchInfo.getId())
+			.riotMatchId(matchInfo.getRiotMatchId())
+			.kills(matchInfo.getKills())
+			.deaths(matchInfo.getDeaths())
+			.assists(matchInfo.getAssists())
+			.teamPosition(matchInfo.getTeamPosition())
+			.championName(matchInfo.getChampionName())
+			.win(matchInfo.getWin())
+			.matchAnalysis(matchInfo.getMatchAnalysis())
+			.build();
+	}
+}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/matchInfo/dto/TimelineMatchInfoDto.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/matchInfo/dto/TimelineMatchInfoDto.java
@@ -1,0 +1,24 @@
+package com.matching.ezgg.domain.matchInfo.dto;
+
+import com.matching.ezgg.domain.matchInfo.entity.MatchInfo;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TimelineMatchInfoDto {
+	private Long memberId;
+	private String riotMatchId;
+	private String teamPosition;
+	private String championName;
+
+	public static TimelineMatchInfoDto toDto(MatchInfo matchInfo) {
+		return TimelineMatchInfoDto.builder()
+			.memberId(matchInfo.getMemberId())
+			.riotMatchId(matchInfo.getRiotMatchId())
+			.teamPosition(matchInfo.getTeamPosition())
+			.championName(matchInfo.getChampionName())
+			.build();
+	}
+}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/matchInfo/service/MatchInfoService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/matchInfo/service/MatchInfoService.java
@@ -3,6 +3,8 @@ package com.matching.ezgg.domain.matchInfo.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.matching.ezgg.domain.matchInfo.dto.MatchInfoDto;
+import com.matching.ezgg.domain.matchInfo.dto.TimelineMatchInfoDto;
 import com.matching.ezgg.domain.matchInfo.entity.MatchInfo;
 import com.matching.ezgg.domain.matchInfo.repository.MatchInfoRepository;
 import com.matching.ezgg.domain.riotApi.dto.MatchDto;
@@ -36,8 +38,16 @@ public class MatchInfoService {
 		log.info("[INFO] match 저장 종료: {}", matchDto.getRiotMatchId());
 	}
 
-	public MatchInfo getMatchByMemberIdAndRiotMatchId(Long memberId, String matchId) {
+	private MatchInfo getMatchInfoOrThrow(Long memberId, String matchId) {
 		return matchInfoRepository.findByMemberIdAndRiotMatchId(memberId, matchId)
 			.orElseThrow(MatchNotFoundException::new);
+	}
+
+	public MatchInfoDto getMemberInfoByMemberIdAndRiotMatchId(Long memberId, String matchId) {
+		return MatchInfoDto.toMatchInfoDto(getMatchInfoOrThrow(memberId, matchId));
+	}
+
+	public TimelineMatchInfoDto getTimelineMemberInfoByMemberIdAndRiotMatchId(Long memberId, String matchId) {
+		return TimelineMatchInfoDto.toDto(getMatchInfoOrThrow(memberId, matchId));
 	}
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/member/controller/MemberController.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import com.matching.ezgg.domain.member.dto.SignupResponse;
 import com.matching.ezgg.domain.member.jwt.filter.JWTUtil;
 import com.matching.ezgg.domain.member.jwt.repository.RedisRefreshTokenRepository;
 import com.matching.ezgg.domain.member.service.MemberService;
+import com.matching.ezgg.domain.memberInfo.dto.MemberInfoDto;
 import com.matching.ezgg.domain.memberInfo.entity.MemberInfo;
 import com.matching.ezgg.domain.matching.service.MemberDataBundleService;
 import com.matching.ezgg.domain.memberInfo.service.MemberInfoService;
@@ -85,12 +86,12 @@ public class MemberController {
 	}
 
 	@GetMapping("/memberinfo")
-	public ResponseEntity<SuccessResponse<MemberInfo>> getMemberInfo(@LoginUser Long memberId) {
+	public ResponseEntity<SuccessResponse<MemberInfoDto>> getMemberInfo(@LoginUser Long memberId) {
 		// 로그인한 사용자의 ID를 사용하여 회원 정보를 조회
 		log.info(">>>>> 로그인한 사용자의 ID: {}", memberId);
-		MemberInfo loggedMemberInfo = memberInfoService.getMemberInfoByMemberId(memberId);
+		MemberInfoDto loggedMemberInfo = memberInfoService.getMemberInfoByMemberId(memberId);
 
-		return ResponseEntity.ok(SuccessResponse.<MemberInfo>builder()
+		return ResponseEntity.ok(SuccessResponse.<MemberInfoDto>builder()
 			.code("200")
 			.message("회원정보 조회 성공")
 			.data(loggedMemberInfo)

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/memberInfo/dto/MemberInfoDto.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/memberInfo/dto/MemberInfoDto.java
@@ -1,5 +1,7 @@
 package com.matching.ezgg.domain.memberInfo.dto;
 
+import java.util.List;
+
 import com.matching.ezgg.domain.memberInfo.entity.MemberInfo;
 
 import lombok.AllArgsConstructor;
@@ -12,8 +14,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class MemberInfoDto {
+	private Long memberId;
 	private String riotUsername;
 	private String riotTag;
+	private String puuid;
+	private List<String> matchIds;
 	private String tier;
 	private String tierNum;
 	private Integer wins;
@@ -21,8 +26,11 @@ public class MemberInfoDto {
 
 	public static MemberInfoDto toDto(MemberInfo memberInfo) {
 		return MemberInfoDto.builder()
+			.memberId(memberInfo.getMemberId())
 			.riotUsername(memberInfo.getRiotUsername())
 			.riotTag(memberInfo.getRiotTag())
+			.puuid(memberInfo.getPuuid())
+			.matchIds(memberInfo.getMatchIds())
 			.tier(memberInfo.getTier())
 			.tierNum(memberInfo.getTierNum())
 			.wins(memberInfo.getWins())

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/memberInfo/dto/TimelineMemberInfoDto.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/memberInfo/dto/TimelineMemberInfoDto.java
@@ -1,0 +1,24 @@
+package com.matching.ezgg.domain.memberInfo.dto;
+
+import com.matching.ezgg.domain.memberInfo.entity.MemberInfo;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TimelineMemberInfoDto {
+	private Long memberId;
+	private String riotUsername;
+	private String riotTag;
+	private String puuid;
+
+	public static TimelineMemberInfoDto toDto(MemberInfo memberInfo) {
+		return TimelineMemberInfoDto.builder()
+			.memberId(memberInfo.getMemberId())
+			.riotUsername(memberInfo.getRiotUsername())
+			.riotTag(memberInfo.getRiotTag())
+			.puuid(memberInfo.getPuuid())
+			.build();
+	}
+}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/memberInfo/service/MemberInfoService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/memberInfo/service/MemberInfoService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.matching.ezgg.domain.memberInfo.dto.MemberInfoDto;
+import com.matching.ezgg.domain.memberInfo.dto.TimelineMemberInfoDto;
 import com.matching.ezgg.domain.memberInfo.entity.MemberInfo;
 import com.matching.ezgg.domain.memberInfo.repository.MemberInfoRepository;
 import com.matching.ezgg.domain.riotApi.dto.WinRateNTierDto;
@@ -45,8 +46,16 @@ public class MemberInfoService {
 	}
 
 	// memberId로 MemberInfo 조회
-	public MemberInfo getMemberInfoByMemberId(Long memberId) {
+	private MemberInfo getMemberInfoOrThrow(Long memberId) {
 		return memberInfoRepository.findByMemberId(memberId).orElseThrow(MemberInfoNotFoundException::new);
+	}
+
+	public MemberInfoDto getMemberInfoByMemberId(Long memberId) {
+		return MemberInfoDto.toDto(getMemberInfoOrThrow(memberId));
+	}
+
+	public TimelineMemberInfoDto getTimelineMemberInfoByMemberId(Long memberId) {
+		return TimelineMemberInfoDto.toDto(getMemberInfoOrThrow(memberId));
 	}
 
 	//member info 생성
@@ -85,7 +94,7 @@ public class MemberInfoService {
 	public MemberInfo updateMemberInfo(Long memberId, WinRateNTierDto winRateNTierDto, List<String> fetchedMatchIds,
 		boolean existsNewMatchIds) {
 		log.info("MemberInfo 업데이트 시작");
-		MemberInfo memberInfo = getMemberInfoByMemberId(memberId);
+		MemberInfo memberInfo = getMemberInfoOrThrow(memberId);
 		memberInfo.update(
 			winRateNTierDto.getTier(),
 			winRateNTierDto.getTierNum(),

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/memberInfo/service/MemberInfoService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/memberInfo/service/MemberInfoService.java
@@ -38,8 +38,10 @@ public class MemberInfoService {
 	}
 
 	// puuid로 MemberInfo 조회
-	public MemberInfo getMemberInfoByPuuid(String puuid) {
-		return memberInfoRepository.findByPuuid(puuid).orElseThrow(MemberInfoNotFoundException::new);
+	public MemberInfoDto getMemberInfoByPuuid(String puuid) {
+		return MemberInfoDto.toDto(
+			memberInfoRepository.findByPuuid(puuid).orElseThrow(MemberInfoNotFoundException::new)
+		);
 	}
 
 	// memberId로 MemberInfo 조회

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/recentTwentyMatch/entity/model/ChampionStat.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/recentTwentyMatch/entity/model/ChampionStat.java
@@ -1,5 +1,6 @@
 package com.matching.ezgg.domain.recentTwentyMatch.entity.model;
 
+import com.matching.ezgg.domain.matchInfo.dto.MatchInfoDto;
 import com.matching.ezgg.domain.matchInfo.entity.MatchInfo;
 
 import lombok.Builder;
@@ -33,11 +34,11 @@ public class ChampionStat {//모스트 3개 캐릭터에 대해서만 생성
 	}
 
 	// match 데이터로 championStat 업데이트
-	public void updateByMatch(MatchInfo matchInfo) {
-		this.kills += matchInfo.getKills();
-		this.deaths += matchInfo.getDeaths();
-		this.assists += matchInfo.getAssists();
-		addMatchResult(Boolean.TRUE.equals(matchInfo.getWin()));
+	public void updateByMatch(MatchInfoDto matchInfoDto) {
+		this.kills += matchInfoDto.getKills();
+		this.deaths += matchInfoDto.getDeaths();
+		this.assists += matchInfoDto.getAssists();
+		addMatchResult(Boolean.TRUE.equals(matchInfoDto.getWin()));
 	}
 
 	// 승패 여부 기록

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/recentTwentyMatch/service/RecentTwentyMatchBuilderService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/recentTwentyMatch/service/RecentTwentyMatchBuilderService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import com.matching.ezgg.domain.matchInfo.entity.MatchInfo;
 import com.matching.ezgg.domain.matchInfo.matchKeyword.lane.Lane;
 import com.matching.ezgg.domain.matchInfo.service.MatchInfoService;
+import com.matching.ezgg.domain.memberInfo.dto.MemberInfoDto;
 import com.matching.ezgg.domain.memberInfo.entity.MemberInfo;
 import com.matching.ezgg.domain.memberInfo.service.MemberInfoService;
 import com.matching.ezgg.domain.recentTwentyMatch.dto.RecentTwentyMatchDto;
@@ -33,11 +34,9 @@ public class RecentTwentyMatchBuilderService {
 	public RecentTwentyMatchDto buildDto(String puuid) {
 		log.info("recentTwentyMatch 계산 시작");
 
-		MemberInfo memberInfo = memberInfoService.getMemberInfoByPuuid(puuid);
-		// matchIds 조회
-		List<String> matchIds = memberInfo.getMatchIds();
-		// member_Id 조회
-		Long memberId = memberInfo.getMemberId();
+		MemberInfoDto memberInfoDto = memberInfoService.getMemberInfoByPuuid(puuid);
+		List<String> matchIds = memberInfoDto.getMatchIds();
+		Long memberId = memberInfoDto.getMemberId();
 
 		// recentTwentyMatch에 들어갈 값 계산(sumKills, sumDeaths, sumAssists, wins, losses, allChampionStat)
 		AggregateResult result = calculateAggregateStatsFromMatches(matchIds, memberId);

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/recentTwentyMatch/service/RecentTwentyMatchBuilderService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/recentTwentyMatch/service/RecentTwentyMatchBuilderService.java
@@ -10,11 +10,11 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.matching.ezgg.domain.matchInfo.dto.MatchInfoDto;
 import com.matching.ezgg.domain.matchInfo.entity.MatchInfo;
 import com.matching.ezgg.domain.matchInfo.matchKeyword.lane.Lane;
 import com.matching.ezgg.domain.matchInfo.service.MatchInfoService;
 import com.matching.ezgg.domain.memberInfo.dto.MemberInfoDto;
-import com.matching.ezgg.domain.memberInfo.entity.MemberInfo;
 import com.matching.ezgg.domain.memberInfo.service.MemberInfoService;
 import com.matching.ezgg.domain.recentTwentyMatch.dto.RecentTwentyMatchDto;
 import com.matching.ezgg.domain.recentTwentyMatch.entity.model.ChampionStat;
@@ -88,13 +88,13 @@ public class RecentTwentyMatchBuilderService {
 
 		// 최근 20 경기의 matchId들로 RecentTwentyMatch 업데이트
 		for (String matchId : matchIds) {
-			MatchInfo matchInfo = matchInfoService.getMatchByMemberIdAndRiotMatchId(memberId, matchId);
+			MatchInfoDto matchInfoDto = matchInfoService.getMemberInfoByMemberIdAndRiotMatchId(memberId, matchId);
 
-			result.sumKills += matchInfo.getKills();
-			result.sumDeaths += matchInfo.getDeaths();
-			result.sumAssists += matchInfo.getAssists();
+			result.sumKills += matchInfoDto.getKills();
+			result.sumDeaths += matchInfoDto.getDeaths();
+			result.sumAssists += matchInfoDto.getAssists();
 
-			if (Boolean.TRUE.equals(matchInfo.getWin())) {
+			if (Boolean.TRUE.equals(matchInfoDto.getWin())) {
 				result.wins++;
 			} else {
 				result.losses++;
@@ -102,32 +102,32 @@ public class RecentTwentyMatchBuilderService {
 
 			// championStat 업데이트
 			result.allChampionStats
-				.computeIfAbsent(matchInfo.getChampionName().trim().toLowerCase(),
+				.computeIfAbsent(matchInfoDto.getChampionName().trim().toLowerCase(),
 					name -> ChampionStat.builder()
 						.championName(name)
 						.build())// 해당 챔피언이 처음으로 기록될때만 ChampionStat 객체 생성. 있을 시에는 해당 championStat 객체에 updateByMatch메서드 바로 적용
-				.updateByMatch(matchInfo);
+				.updateByMatch(matchInfoDto);
 
 			// 라인별 analysis 업데이트
 			Lane lane = null;
 
 			try {
-				lane = Lane.valueOf(matchInfo.getTeamPosition());
+				lane = Lane.valueOf(matchInfoDto.getTeamPosition());
 			} catch (IllegalArgumentException | NullPointerException e) {
 				throw new IllegalArgumentException("유효하지 않은 Lane명 입니다.", e);
 			}
 
-			if (matchInfo.getMatchAnalysis() != null) {
+			if (matchInfoDto.getMatchAnalysis() != null) {
 				if (Lane.TOP == lane) {
-					result.topAnalysisBuilder.append(matchInfo.getMatchAnalysis());
+					result.topAnalysisBuilder.append(matchInfoDto.getMatchAnalysis());
 				} else if (Lane.JUNGLE == lane) {
-					result.jugAnalysisBuilder.append(matchInfo.getMatchAnalysis());
+					result.jugAnalysisBuilder.append(matchInfoDto.getMatchAnalysis());
 				} else if (Lane.MIDDLE == lane) {
-					result.midAnalysisBuilder.append(matchInfo.getMatchAnalysis());
+					result.midAnalysisBuilder.append(matchInfoDto.getMatchAnalysis());
 				} else if (Lane.BOTTOM == lane) {
-					result.adAnalysisBuilder.append(matchInfo.getMatchAnalysis());
+					result.adAnalysisBuilder.append(matchInfoDto.getMatchAnalysis());
 				} else if (Lane.UTILITY == lane) {
-					result.supAnalysisBuilder.append(matchInfo.getMatchAnalysis());
+					result.supAnalysisBuilder.append(matchInfoDto.getMatchAnalysis());
 				}
 			}
 		}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/review/service/ReviewService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/review/service/ReviewService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 
 import com.matching.ezgg.domain.matching.infra.redis.service.RedisService;
+import com.matching.ezgg.domain.memberInfo.dto.MemberInfoDto;
 import com.matching.ezgg.domain.memberInfo.entity.MemberInfo;
 import com.matching.ezgg.domain.memberInfo.service.MemberInfoService;
 import com.matching.ezgg.domain.review.entity.Review;
@@ -31,8 +32,8 @@ public class ReviewService {
 	private final MatchMapper matchMapper;
 
 	public void findDuoGame(Long memberId1, Long memberId2, Map<String, String> updateMatchedUser) {
-		MemberInfo memberInfoByMember1 = memberInfoService.getMemberInfoByMemberId(memberId1);
-		MemberInfo memberInfoByMember2 = memberInfoService.getMemberInfoByMemberId(memberId2);
+		MemberInfoDto memberInfoByMember1 = memberInfoService.getMemberInfoByMemberId(memberId1);
+		MemberInfoDto memberInfoByMember2 = memberInfoService.getMemberInfoByMemberId(memberId2);
 
 		List<String> member1MatchIds = memberInfoByMember1.getMatchIds();
 		List<String> findMember1MatchIds = apiService.getMemberMatchIds(memberInfoByMember1.getPuuid());

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/riotApi/service/ApiService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/riotApi/service/ApiService.java
@@ -12,6 +12,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.matching.ezgg.domain.matchInfo.matchKeyword.service.KeywordAnalyzerService;
 import com.matching.ezgg.domain.memberInfo.service.MemberInfoService;
 import com.matching.ezgg.domain.riotApi.dto.MatchDto;
@@ -50,7 +51,7 @@ public class ApiService {
 		this.keywordAnalyzerService = keywordAnalyzerService;
 	}
 
-	//riot/account/v1/accounts/by-riot-id/{riot-id}/{tag}?api_key=
+	// riot/account/v1/accounts/by-riot-id/{riot-id}/{tag}?api_key=
 	// 유저 id, tag -> Riot api -> puuid를 수령
 	public String getMemberPuuid(String riotId, String tag) {
 		log.info("puuid 조회 시작: {}#{}", riotId, tag);
@@ -77,7 +78,7 @@ public class ApiService {
 		}
 	}
 
-	// /lol/league/v4/entries/by-puuid/{encryptedPUUID}
+	// lol/league/v4/entries/by-puuid/{encryptedPUUID}
 	// puuid -> Riot api -> tier, rank, wins, losses 수령
 	public WinRateNTierDto getMemberWinRateNTier(String puuid) {
 		log.info("승률/티어 조회 시작: {}", puuid);
@@ -114,7 +115,7 @@ public class ApiService {
 		}
 	}
 
-	//lol/match/v5/matches/by-puuid/{puuid}/ids?type=ranked&start=0&count=20&api_key=apiKey
+	// lol/match/v5/matches/by-puuid/{puuid}/ids?type=ranked&start=0&count=20&api_key=apiKey
 	// puuid -> Riot api -> 최근 랭크 경기 20개의 matchIds 배열로 수령
 	public List<String> getMemberMatchIds(String puuid) {
 		log.info("MatchIds 조회 시작: {}", puuid);
@@ -152,7 +153,7 @@ public class ApiService {
 		}
 	}
 
-	//lol/match/v5/matches/{matchId}?api_key=
+	// lol/match/v5/matches/{matchId}?api_key=
 	public MatchDto getMemberMatch(Long memberId, String puuid, String matchId) {
 		log.info("matchInfo 조회 시작: puuid = {} / matchId = {}", puuid, matchId);
 
@@ -180,6 +181,22 @@ public class ApiService {
 			throw new RiotMatchNotFoundException(matchId);
 		} catch (RiotApiException e) {
 			throw new RiotApiException("Match 조회 Riot Api 실패");
+		}
+	}
+
+	// lol/match/v5/matches/{matchId}/timeline?api_key=
+	public JsonNode getDuoMatchTimeline(String matchId) {
+		try {
+			String url = String.format(
+				"/lol/match/v5/matches/%s/timeline?api_key=%s",
+				matchId, apiKey
+			);
+
+			return asiaRestTemplate.getForObject(url, JsonNode.class);
+		} catch (RiotMatchNotFoundException e) {
+			throw new RiotMatchNotFoundException(matchId);
+		} catch (RiotApiException e) {
+			throw new RiotApiException("Match timeline 조회 Riot Api 실패 : MatchId : " + matchId);
 		}
 	}
 

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/riotApi/util/MatchMapper.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/riotApi/util/MatchMapper.java
@@ -1,20 +1,28 @@
 package com.matching.ezgg.domain.riotApi.util;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.StreamSupport;
 
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.matching.ezgg.domain.matchInfo.dto.TimelineMatchInfoDto;
 import com.matching.ezgg.domain.matchInfo.matchKeyword.dto.GlobalMatchParsingDto;
 import com.matching.ezgg.domain.matchInfo.matchKeyword.dto.JugMatchParsingDto;
 import com.matching.ezgg.domain.matchInfo.matchKeyword.dto.LanerMatchParsingDto;
 import com.matching.ezgg.domain.matchInfo.matchKeyword.dto.SupMatchParsingDto;
 import com.matching.ezgg.domain.matchInfo.matchKeyword.lane.Lane;
+import com.matching.ezgg.domain.memberInfo.dto.TimelineMemberInfoDto;
 import com.matching.ezgg.domain.riotApi.dto.MatchDto;
 import com.matching.ezgg.domain.riotApi.dto.MatchReviewDto;
+import com.matching.ezgg.domain.timeline.dto.DuoTimelineDto;
+import com.matching.ezgg.domain.timeline.dto.DuoTimelineDto.*;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,6 +58,121 @@ public class MatchMapper {
 		} catch (JsonProcessingException e) {
 			throw new IllegalArgumentException("JSON → MatchDto 변환 실패", e);
 		}
+	}
+
+	// DuoTimeline에 사용될 데이터 추출 메서드
+	public DuoTimelineDto extractDuoTimelineDto(
+		JsonNode timelineData, TimelineMemberInfoDto memberInfoDto, TimelineMemberInfoDto duoMemberInfoDto,
+		TimelineMatchInfoDto timelineMatchInfoDto, TimelineMatchInfoDto duoTimelineMatchInfoDto
+	) {
+		Map<Integer, UserMatchInfoDto> userMatchInfos = extractUserMatchInfos(
+			timelineData.path("participants"), memberInfoDto, duoMemberInfoDto, timelineMatchInfoDto,
+			duoTimelineMatchInfoDto
+		);
+		List<DuoTimelineDto.DuoFrameEventDto> timeline = extractDuoFrameEvents(
+			timelineData.path("frames"), userMatchInfos.keySet()
+		);
+
+		DuoTimelineDto dto = new DuoTimelineDto();
+		dto.setTimeline(timeline);
+		dto.setUserMatchInfos(userMatchInfos);
+		return dto;
+	}
+
+	private Map<Integer, UserMatchInfoDto> extractUserMatchInfos(
+		JsonNode participantsNode, TimelineMemberInfoDto memberInfo, TimelineMemberInfoDto duoMemberInfo,
+		TimelineMatchInfoDto memberMatchInfo, TimelineMatchInfoDto duoMemberMatchInfo
+	) {
+		Map<Integer, UserMatchInfoDto> map = new HashMap<>();
+
+		for (JsonNode participant : participantsNode) {
+			String puuid = participant.path("puuid").asText();
+			int participantId = participant.path("participantId").asInt();
+
+			if (puuid.equals(memberInfo.getPuuid())) {
+				DuoTimelineDto.UserMatchInfoDto info = new DuoTimelineDto.UserMatchInfoDto();
+				info.setTimelineMemberInfoDto(memberInfo);
+				info.setTimelineMatchInfoDto(memberMatchInfo);
+				map.put(participantId, info);
+			} else if (puuid.equals(duoMemberInfo.getPuuid())) {
+				DuoTimelineDto.UserMatchInfoDto info = new DuoTimelineDto.UserMatchInfoDto();
+				info.setTimelineMemberInfoDto(duoMemberInfo);
+				info.setTimelineMatchInfoDto(duoMemberMatchInfo);
+				map.put(participantId, info);
+			}
+		}
+
+		return map;
+	}
+
+	private List<DuoTimelineDto.DuoFrameEventDto> extractDuoFrameEvents(
+		JsonNode framesNode, Set<Integer> participantIds) {
+		List<DuoTimelineDto.DuoFrameEventDto> result = new ArrayList<>();
+
+		for (JsonNode frameNode : framesNode) {
+			List<DuoTimelineDto.TimelineEventDto> events = new ArrayList<>();
+
+			for (JsonNode eventNode : frameNode.path("events")) {
+				String type = eventNode.path("type").asText();
+				if (isTargetEvent(type) && isDuoRelated(eventNode, participantIds)) {
+					events.add(convertToTimelineEventDto(eventNode, type));
+				}
+			}
+
+			// todo participantStatus 추출 (현재는 빈 Map, 향후 구현 필요)
+			Map<Integer, DuoTimelineDto.ParticipantStatusDto> participantStatus = new HashMap<>();
+
+			if (events.isEmpty() && participantStatus.isEmpty()) {
+				continue;
+			}
+
+			DuoTimelineDto.DuoFrameEventDto frameEvent = new DuoTimelineDto.DuoFrameEventDto();
+			frameEvent.setTimestamp(frameNode.path("timestamp").asLong());
+			frameEvent.setEvents(events);
+			frameEvent.setParticipantStatus(participantStatus);
+
+			result.add(frameEvent);
+		}
+
+		return result;
+	}
+
+	private DuoTimelineDto.TimelineEventDto convertToTimelineEventDto(JsonNode eventNode, String type) {
+		DuoTimelineDto.TimelineEventDto dto = new DuoTimelineDto.TimelineEventDto();
+		dto.setType(type);
+		if (eventNode.has("killerId"))
+			dto.setKillerId(eventNode.get("killerId").asInt());
+		if (eventNode.has("victimId"))
+			dto.setVictimId(eventNode.get("victimId").asInt());
+		if (eventNode.has("assistingParticipantIds")) {
+			List<Integer> assists = new ArrayList<>();
+			eventNode.get("assistingParticipantIds").forEach(a -> assists.add(a.asInt()));
+			dto.setAssistingParticipantIds(assists);
+		}
+		if (type.equals("CHAMPION_SPECIAL_KILL") && eventNode.has("killType")) {
+			dto.setDetail(eventNode.get("killType").asText());
+		}
+		return dto;
+	}
+
+	private boolean isDuoRelated(JsonNode eventNode, Set<Integer> participantIdSet) {
+		return (eventNode.has("participantId") && participantIdSet.contains(eventNode.get("participantId").asInt())) ||
+			(eventNode.has("killerId") && participantIdSet.contains(eventNode.get("killerId").asInt())) ||
+			(eventNode.has("victimId") && participantIdSet.contains(eventNode.get("victimId").asInt())) ||
+			(eventNode.has("assistingParticipantIds") &&
+				StreamSupport.stream(eventNode.get("assistingParticipantIds").spliterator(), false)
+					.map(JsonNode::asInt)
+					.anyMatch(participantIdSet::contains));
+	}
+
+	private boolean isTargetEvent(String type) {
+		return Set.of(
+			"CHAMPION_KILL",
+			"CHAMPION_SPECIAL_KILL",
+			"ELITE_MONSTER_KILL",
+			"BUILDING_KILL",
+			"TURRET_PLATE_DESTROYED"
+		).contains(type);
 	}
 
 	// participant 배열에서 puuid가 일치하는 노드 리턴
@@ -182,16 +305,20 @@ public class MatchMapper {
 			JsonNode lanerChallengesNode = findChallenges(lanerNode);
 
 			//상대 라이너 정보 파싱
-			JsonNode opponentLanerNode = findOpponentMember(root.path("info").path("participants"), puuid,
-				teamPosition);
+			JsonNode opponentLanerNode = findOpponentMember(
+				root.path("info").path("participants"), puuid,
+				teamPosition
+			);
 			JsonNode opponentLanerChallengesNode = findChallenges(opponentLanerNode);
 
 			return LanerMatchParsingDto.builder()
 				.turretKills(lanerNode.path("turretKills").asInt())
 				.turretsLost(lanerNode.path("turretsLost").asInt())
 				.firstBloodKill(lanerNode.path("firstBloodKill").asBoolean())
-				.killsOnOtherLanesEarlyJungleAsLaner(lanerChallengesNode.path("killsOnOtherLanesEarlyJungleAsLaner").asInt())
-				.getTakedownsInAllLanesEarlyJungleAsLaner(lanerChallengesNode.path("getTakedownsInAllLanesEarlyJungleAsLaner").asInt())
+				.killsOnOtherLanesEarlyJungleAsLaner(
+					lanerChallengesNode.path("killsOnOtherLanesEarlyJungleAsLaner").asInt())
+				.getTakedownsInAllLanesEarlyJungleAsLaner(
+					lanerChallengesNode.path("getTakedownsInAllLanesEarlyJungleAsLaner").asInt())
 				.turretPlatesTaken(lanerChallengesNode.path("turretPlatesTaken").asInt())
 				.killsUnderOwnTurret(lanerChallengesNode.path("killsUnderOwnTurret").asInt())
 				.killsNearEnemyTurret(lanerChallengesNode.path("killsNearEnemyTurret").asInt())
@@ -213,12 +340,15 @@ public class MatchMapper {
 			JsonNode jugChallengesNode = findChallenges(jugNode);
 
 			//상대 정글 정보 파싱
-			JsonNode opponentJugNode = findOpponentMember(root.path("info").path("participants"), puuid,
-				Lane.JUNGLE.name());
+			JsonNode opponentJugNode = findOpponentMember(
+				root.path("info").path("participants"), puuid,
+				Lane.JUNGLE.name()
+			);
 			JsonNode opponentJugChallengesNode = findChallenges(opponentJugNode);
 
 			return JugMatchParsingDto.builder()
-				.visionScoreAdvantageLaneOpponent(jugChallengesNode.path("visionScoreAdvantageLaneOpponent").doubleValue())
+				.visionScoreAdvantageLaneOpponent(
+					jugChallengesNode.path("visionScoreAdvantageLaneOpponent").doubleValue())
 				.epicMonsterSteals(jugChallengesNode.path("epicMonsterSteals").asInt())
 				.enemyJungleMonsterKills(jugChallengesNode.path("enemyJungleMonsterKills").asInt())
 				.riftHeraldTakedowns(jugChallengesNode.path("riftHeraldTakedowns").asInt())
@@ -229,7 +359,8 @@ public class MatchMapper {
 				.opponentBaronTakedowns(opponentJugChallengesNode.path("baronTakedowns").asInt())
 				.firstBloodKill(jugNode.path("firstBloodKill").asBoolean())
 				.moreEnemyJungleThanOpponent(jugChallengesNode.path("moreEnemyJungleThanOpponent").asDouble())
-				.opponentMoreEnemyJungleThanOpponent(opponentJugChallengesNode.path("moreEnemyJungleThanOpponent").asDouble())
+				.opponentMoreEnemyJungleThanOpponent(
+					opponentJugChallengesNode.path("moreEnemyJungleThanOpponent").asDouble())
 				.multiTurretRiftHeraldCount(jugChallengesNode.path("multiTurretRiftHeraldCount").asInt())
 				.build();
 

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/timeline/dto/DuoTimelineDto.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/timeline/dto/DuoTimelineDto.java
@@ -1,0 +1,54 @@
+package com.matching.ezgg.domain.timeline.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import com.matching.ezgg.domain.matchInfo.dto.TimelineMatchInfoDto;
+import com.matching.ezgg.domain.memberInfo.dto.TimelineMemberInfoDto;
+
+import lombok.Data;
+
+@Data
+public class DuoTimelineDto {
+
+	private List<DuoFrameEventDto> timeline;
+	private Map<Integer, UserMatchInfoDto> userMatchInfos;
+
+	@Data
+	public static class UserMatchInfoDto {
+		private TimelineMemberInfoDto timelineMemberInfoDto;
+		private TimelineMatchInfoDto timelineMatchInfoDto;
+	}
+
+	@Data
+	public static class DuoFrameEventDto {
+		private long timestamp;
+		private List<TimelineEventDto> events;
+		private Map<Integer, ParticipantStatusDto> participantStatus;
+	}
+
+	@Data
+	public static class TimelineEventDto {
+		private String type;
+		private Integer killerId;
+		private Integer victimId;
+		private List<Integer> assistingParticipantIds;
+		private String detail; // ex: SPECIAL_KILL
+	}
+
+	@Data
+	public class ParticipantStatusDto {
+		private int level;
+		private int totalGold;
+		private int minionsKilled;
+		private int jungleMinionsKilled;
+		private DamageStatsDto damageStats;
+	}
+
+	@Data
+	public class DamageStatsDto {
+		private int totalDamageDealt;
+		private int totalDamageTaken;
+		private int damageToChampions;
+	}
+}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/timeline/service/DuoTimelineService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/timeline/service/DuoTimelineService.java
@@ -1,0 +1,48 @@
+package com.matching.ezgg.domain.timeline.service;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.matching.ezgg.domain.matchInfo.dto.TimelineMatchInfoDto;
+import com.matching.ezgg.domain.matchInfo.service.MatchInfoService;
+import com.matching.ezgg.domain.memberInfo.dto.TimelineMemberInfoDto;
+import com.matching.ezgg.domain.memberInfo.service.MemberInfoService;
+import com.matching.ezgg.domain.riotApi.service.ApiService;
+import com.matching.ezgg.domain.riotApi.util.MatchMapper;
+import com.matching.ezgg.domain.timeline.dto.DuoTimelineDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class DuoTimelineService {
+
+	private final ApiService apiService;
+	private final MatchMapper matchMapper;
+	private final MemberInfoService memberInfoService;
+	private final MatchInfoService matchInfoService;
+
+	public DuoTimelineDto getDuoMatchTimeline() {
+		Long memberId = 1L;
+		Long duoMemberId = 2L;
+		String matchId = "KR_7650709888";
+
+		// Riot Api - Timeline 정보 가져오기
+		JsonNode matchTimelineInfo = apiService.getDuoMatchTimeline(matchId).path("info");
+
+		// memberId, matchId => timeline 정보 가져오기
+		TimelineMemberInfoDto timelineMemberInfoDto = memberInfoService.getTimelineMemberInfoByMemberId(memberId);
+		TimelineMemberInfoDto duoTimelineMemberInfoDto = memberInfoService.getTimelineMemberInfoByMemberId(duoMemberId);
+		TimelineMatchInfoDto timelineMatchInfoDto = matchInfoService.getTimelineMemberInfoByMemberIdAndRiotMatchId(
+			memberId, matchId
+		);
+		TimelineMatchInfoDto duoTimelineMatchInfoDto = matchInfoService.getTimelineMemberInfoByMemberIdAndRiotMatchId(
+			duoMemberId, matchId
+		);
+
+		return matchMapper.extractDuoTimelineDto(
+			matchTimelineInfo, timelineMemberInfoDto, duoTimelineMemberInfoDto, timelineMatchInfoDto,
+			duoTimelineMatchInfoDto
+		);
+	}
+}


### PR DESCRIPTION
## 🔎 작업 내용

- matchId 해당하는 timeline API 조회
- timeline Dto에 맞게 다른 Dto 수정
  - service에서 항상 dto를 반환할 수 있도록 entity 반환 메서드는 private로 분리
  - 다른 서비스에 요구하는 dto에 맞게 반환하도록 메서드 분리




## 🔧 앞으로의 과제

- duo timeline FE 화면 구성
- match API 통해 1 ~ 10 (챔피언) 정보 dto에 추가 저장
- timeline 데이터에 ParticipantStatusDto 정보 채우기
  - 마지막 timeline 기준 최종 정보들 (딜량, CS 등)